### PR TITLE
added prop to enable quick create button

### DIFF
--- a/PolyLookupComponent/PolyLookup/ControlManifest.Input.xml
+++ b/PolyLookupComponent/PolyLookup/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="PolyLookup" version="1.0.11" display-name-key="PolyLookup" description-key="Multi-select lookup supporting different type of many-to-many relationships. v1.0.10" control-type="virtual" >
+  <control namespace="DCEPCF" constructor="PolyLookup" version="1.0.12" display-name-key="PolyLookup" description-key="Multi-select lookup supporting different type of many-to-many relationships. v1.0.10" control-type="virtual" >
     <!--external-service-usage node declares whether this 3rd party PCF control is using external service or not, if yes, this control will be considered as premium and please also add the external domain it is using.
     If it is not using any external service, please set the enabled="false" and DO NOT add any domain below. The "enabled" will be false by default.
     Example1:
@@ -31,6 +31,10 @@
     </property>
     <property name="sortAttribute" display-name-key="Sort By" description-key="Sort suggestions by attribute name with direction (asc/desc). Default: the Primary Name Attribute of the associated table ascending. Ex: temp_name or temp_name desc" of-type="SingleLine.Text" usage="input" required="false" />
     <property name="itemLimit" display-name-key="Item Limit" description-key="Maximum number of selected items" of-type="Whole.None" usage="input" required="false" />
+    <property name="allowQuickCreate" display-name-key="Allow Quick Create" description-key="Enable/disable the create button to quickly create a new option" of-type="Enum" usage="input" required="false" >
+      <value name="false" display-name-key="No">0</value>
+      <value name="true" display-name-key="Yes">1</value>
+    </property>
     <!--
       Property node's of-type attribute can be of-type-group attribute.
       Example:

--- a/PolyLookupComponent/PolyLookup/components/PolyLookupControl.tsx
+++ b/PolyLookupComponent/PolyLookup/components/PolyLookupControl.tsx
@@ -41,7 +41,8 @@ export interface PolyLookupProps {
   onQuickCreate?: (
     entityName: string | undefined,
     primaryAttribute: string | undefined,
-    value: string | undefined
+    value: string | undefined,
+    useQuickCreateForm: boolean | undefined
   ) => Promise<string | undefined>;
 }
 
@@ -277,7 +278,12 @@ export const Body = ({
 
   const onCreateNew = (input: string): ValidationState => {
     if (onQuickCreate) {
-      onQuickCreate(associatedTableDefinition?.LogicalName, associatedTableDefinition?.PrimaryNameAttribute, input)
+      onQuickCreate(
+        associatedTableDefinition?.LogicalName,
+        associatedTableDefinition?.PrimaryNameAttribute,
+        input,
+        associatedTableDefinition?.IsQuickCreateEnabled
+      )
         .then((result) => {
           if (result) {
             associateQuery.mutate(result);

--- a/PolyLookupComponent/PolyLookup/index.ts
+++ b/PolyLookupComponent/PolyLookup/index.ts
@@ -77,34 +77,38 @@ export class PolyLookup implements ComponentFramework.ReactControl<IInputs, IOut
   public onQuickCreate = async (
     entityName: string | undefined,
     primaryAttribute: string | undefined,
-    value: string | undefined
+    value: string | undefined,
+    useQuickCreateForm: boolean | undefined
   ) => {
     if (entityName && primaryAttribute) {
-      var result = await this.context.navigation.navigateTo(
-        {
-          pageType: "entityrecord",
-          entityName: entityName,
-          data: {
-            [primaryAttribute]: value ?? "",
+      let result: ComponentFramework.NavigationApi.OpenFormSuccessResponse;
+      if (useQuickCreateForm) {
+        result = await this.context.navigation.openForm(
+          {
+            entityName: entityName,
+            useQuickCreateForm: true,
           },
-        },
-        {
-          target: 2,
-          height: { value: 80, unit: "%" },
-          width: { value: 70, unit: "%" },
-          position: 1,
-        }
-      );
-
-      // const result = await this.context.navigation.openForm(
-      //   {
-      //     entityName: entityName,
-      //     useQuickCreateForm: true,
-      //   },
-      //   {
-      //     [primaryAttribute]: value ?? "",
-      //   }
-      // );
+          {
+            [primaryAttribute]: value ?? "",
+          }
+        );
+      } else {
+        result = await this.context.navigation.navigateTo(
+          {
+            pageType: "entityrecord",
+            entityName: entityName,
+            data: {
+              [primaryAttribute]: value ?? "",
+            },
+          },
+          {
+            target: 2,
+            height: { value: 80, unit: "%" },
+            width: { value: 70, unit: "%" },
+            position: 1,
+          }
+        );
+      }
 
       if (result?.savedEntityReference?.length) {
         return result.savedEntityReference[0].id;

--- a/PolyLookupComponent/PolyLookup/services/DataverseService.ts
+++ b/PolyLookupComponent/PolyLookup/services/DataverseService.ts
@@ -206,7 +206,9 @@ export function associateRecord(
   return axios.post(
     `/api/data/v${apiVersion}/${entitySetName}(${currentRecordId})/${relationshipName}/$ref`,
     {
-      "@odata.id": `${clientUrl}/api/data/v${apiVersion}/${associatedEntitySet}(${associateRecordId})`,
+      "@odata.id": `${clientUrl}/api/data/v${apiVersion}/${associatedEntitySet}(${associateRecordId
+        .replace("{", "")
+        .replace("}", "")})`,
     },
     {
       headers: {

--- a/PolyLookupComponent/PolyLookup/services/DataverseService.ts
+++ b/PolyLookupComponent/PolyLookup/services/DataverseService.ts
@@ -45,6 +45,7 @@ export interface IEntityDefinition {
       Label: string;
     };
   };
+  IsQuickCreateEnabled: boolean;
 }
 
 const nToNColumns = [
@@ -64,6 +65,7 @@ const tableDefinitionColumns = [
   "PrimaryNameAttribute",
   "EntitySetName",
   "DisplayCollectionName",
+  "IsQuickCreateEnabled",
 ];
 
 const apiVersion = "9.2";

--- a/PolyLookupComponent/PolyLookup/types/extendedContext.ts
+++ b/PolyLookupComponent/PolyLookup/types/extendedContext.ts
@@ -1,0 +1,135 @@
+import { IInputs } from "../generated/ManifestTypes";
+
+interface IExtendedUserSettings extends ComponentFramework.UserSettings {
+  pagingLimit: number;
+}
+
+/**
+ * Interface for a Lookup value.
+ */
+interface LookupValue {
+  /**
+   * The identifier.
+   */
+  id: string;
+
+  /**
+   * The name
+   */
+  name?: string | undefined;
+
+  /**
+   * Type of the entity.
+   */
+  entityType: string;
+}
+
+interface PageInputEntityRecord {
+  pageType: "entityrecord";
+  /**
+   * Logical name of the entity to display the form for.
+   * */
+  entityName: string;
+  /**
+   * ID of the entity record to display the form for. If you don't specify this value, the form will be opened in create mode.
+   * */
+  entityId?: string | undefined;
+  /**
+   * Designates a record that will provide default values based on mapped attribute values. The lookup object has the following String properties: entityType, id, and name (optional).
+   */
+  createFromEntity?: LookupValue | undefined;
+  /**
+   * A dictionary object that passes extra parameters to the form. Invalid parameters will cause an error.
+   */
+  data?: { [attributeName: string]: any } | undefined;
+  /**
+   * ID of the form instance to be displayed.
+   */
+  formId?: string | undefined;
+  /**
+   * Indicates whether the form is navigated to from a different entity using cross-entity business process flow.
+   */
+  isCrossEntityNavigate?: boolean | undefined;
+  /**
+   * Indicates whether there are any offline sync errors.
+   */
+  isOfflineSyncError?: boolean | undefined;
+  /**
+   * ID of the business process to be displayed on the form.
+   */
+  processId?: string | undefined;
+  /**
+   * ID of the business process instance to be displayed on the form.
+   */
+  processInstanceId?: string | undefined;
+  /**
+   * Define a relationship object to display the related records on the form.
+   */
+  relationship?: any | undefined;
+  /**
+   * ID of the selected stage in business process instance.
+   */
+  selectedStageId?: string | undefined;
+}
+
+/**
+ * Options for navigating to a page: whether to open inline or in a dialog. If you don't specify this parameter, page is opened inline by default.
+ * */
+interface NavigationOptions {
+  /**
+   * Specify 1 to open the page inline; 2 to open the page in a dialog.
+   * Entity lists can only be opened inline; web resources can be opened either inline or in a dialog.
+   * */
+  target: 1 | 2;
+  /**
+   * The width of dialog. To specify the width in pixels, just type a numeric value. To specify the width in percentage, specify an object of type
+   * */
+  width?: number | SizeValue | undefined;
+  /**
+   * The width of dialog. To specify the width in pixels, just type a numeric value. To specify the width in percentage, specify an object of type
+   * */
+  height?: number | SizeValue | undefined;
+  /**
+   * Specify 1 to open the dialog in center; 2 to open the dialog on the side. Default is 1 (center).
+   * */
+  position?: 1 | 2 | undefined;
+  /*
+   * The dialog title on top of the center or side dialog.
+   */
+  title?: string | undefined;
+}
+
+interface SizeValue {
+  /**
+   * The numerical value
+   * */
+  value: number;
+  /**
+   * The unit of measurement. Specify "%" or "px". Default value is "px"
+   * */
+  unit: "%" | "px";
+}
+
+interface IExtendedNavigation extends ComponentFramework.Navigation {
+  /**
+   * Navigates to the specified page.
+   * @param pageInput Input about the page to navigate to. The object definition changes depending on the type of page to navigate to: entity list or HTML web resource.
+   * @param navigationOptions Options for navigating to a page: whether to open inline or in a dialog. If you don't specify this parameter, page is opened inline by default.
+   */
+  navigateTo(
+    pageInput: PageInputEntityRecord,
+    navigationOptions?: NavigationOptions
+  ): Promise<ComponentFramework.NavigationApi.OpenFormSuccessResponse>;
+}
+
+export interface IExtendedContext extends ComponentFramework.Context<IInputs> {
+  page: {
+    appId: string;
+    entityTypeName: string;
+    entityId: string;
+    isPageReadOnly: boolean;
+    getClientUrl: () => string;
+  };
+  userSettings: IExtendedUserSettings;
+  navigation: IExtendedNavigation;
+}


### PR DESCRIPTION
### Previous Behavior
Users can't quickly create a new option.

### New Behavior
A new prop is introduced to enable/disable the create button.
Users can click the button to quickly create a new option.

### Related Issue(s)
Fixed #9 
fixed useCallback dependencies
