### PR TITLE
use default view if lookup view is empty or not found

### DIFF
--- a/LookdownComponent/Lookdown/components/LookdownControl.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControl.tsx
@@ -28,13 +28,14 @@ export enum IconSizes {
 }
 
 export interface LookdownProps {
-  lookupViewId: string;
-  lookupEntity: string;
+  lookupViewId?: string | null;
+  lookupEntity?: string | null;
   selectedId?: string | null;
   customFilter?: string | null;
   groupBy?: string | null;
   showIcon?: ShowIconOptions;
   iconSize?: IconSizes;
+  disabled?: boolean;
   onChange?: (selectedItem: ComponentFramework.LookupValue | null) => void;
 }
 
@@ -79,6 +80,7 @@ const Body = ({
   groupBy,
   showIcon,
   iconSize,
+  disabled,
   onChange,
 }: LookdownProps) => {
   const {
@@ -229,6 +231,7 @@ const Body = ({
       selectedKey={selectedId ?? undefined}
       placeholder="---"
       options={getDropdownOptions()}
+      disabled={disabled}
       onChange={(event, option) => {
         if (!onChange) return;
         if (!metadata) return;

--- a/LookdownComponent/Lookdown/index.ts
+++ b/LookdownComponent/Lookdown/index.ts
@@ -39,18 +39,21 @@ export class Lookdown implements ComponentFramework.ReactControl<IInputs, IOutpu
   public updateView(context: ComponentFramework.Context<IInputs>): React.ReactElement {
     this.context = context;
 
+    const isAuthoringMode = typeof context.parameters.lookupField?.getViewId === "function" ? false : true;
+
     return React.createElement(LookdownControl, {
-      lookupViewId: context.parameters.lookupField.getViewId(),
-      lookupEntity: context.parameters.lookupField.getTargetEntityType(),
-      selectedId: context.parameters.lookupField.raw.at(0)?.id,
-      customFilter: context.parameters.customFilter.raw,
-      groupBy: context.parameters.groupByField.raw,
-      showIcon: context.parameters.showIcon.raw
+      lookupViewId: isAuthoringMode ? undefined : context.parameters.lookupField.getViewId(),
+      lookupEntity: isAuthoringMode ? undefined : context.parameters.lookupField.getTargetEntityType(),
+      selectedId: context.parameters.lookupField.raw?.at(0)?.id,
+      customFilter: context.parameters.customFilter?.raw,
+      groupBy: context.parameters.groupByField?.raw,
+      showIcon: context.parameters.showIcon?.raw
         ? (Number.parseInt(context.parameters.showIcon.raw) as ShowIconOptions)
         : undefined,
-      iconSize: context.parameters.iconSize.raw
+      iconSize: context.parameters.iconSize?.raw
         ? (Number.parseInt(context.parameters.iconSize.raw) as IconSizes)
         : undefined,
+      disabled: context.mode.isControlDisabled,
       onChange: (value) => {
         this.output = value;
         this.notifyOutputChanged();


### PR DESCRIPTION
### Previous Behavior
- view id empty causing component not loaded

### New Behavior
- use default lookup view when view id is empty or view not found

### Related Issue(s)
- #55 
