### PR TITLE
PolyLookup added tag action

### DIFF
--- a/PolyLookupComponent/PolyLookup/ControlManifest.Input.xml
+++ b/PolyLookupComponent/PolyLookup/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="PolyLookup" version="1.3.0" display-name-key="PolyLookup v1.3.0" description-key="Multi-select lookup supporting different type of many-to-many relationships" control-type="virtual" >
+  <control namespace="DCEPCF" constructor="PolyLookup" version="1.4.0" display-name-key="PolyLookup v1.4.0" description-key="Multi-select lookup supporting different type of many-to-many relationships" control-type="virtual" >
     <!--external-service-usage node declares whether this 3rd party PCF control is using external service or not, if yes, this control will be considered as premium and please also add the external domain it is using.
     If it is not using any external service, please set the enabled="false" and DO NOT add any domain below. The "enabled" will be false by default.
     Example1:
@@ -36,6 +36,13 @@
     <property name="allowQuickCreate" display-name-key="Allow Quick Create" description-key="Enable/disable the create button to quickly create a new option" of-type="Enum" usage="input" required="false" default-value="0" >
       <value name="false" display-name-key="No">0</value>
       <value name="true" display-name-key="Yes">1</value>
+    </property>
+    <property name="tagAction" display-name-key="Tag Action" description-key="Perform an action when a tag is clicked. Default: None" of-type="Enum" usage="input" required="false" default-value="0" >
+      <value name="none" display-name-key="None">0</value>
+      <value name="open-inline" display-name-key="Open Inline">1</value>
+      <value name="open-dialog" display-name-key="Open Dialog">2</value>
+      <value name="open-inline-intersect" display-name-key="Open Inline (Intersect relationship)">3</value>
+      <value name="open-dialog-intersect" display-name-key="Open Dialog (Intersect relationship)">4</value>
     </property>
     <property name="languagePackPath" display-name-key="Language Pack Path" description-key="Path to a resx web resource, relative to the environment url (eg. /webresources/new_/resx/PolyLookup.1033.resx), to be used as Language Pack. Default to English if not provided." of-type="SingleLine.Text" usage="input" required="false" />
     <type-group name="text">

--- a/PolyLookupComponent/PolyLookup/index.ts
+++ b/PolyLookupComponent/PolyLookup/index.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import PolyLookupControl, { PolyLookupProps, RelationshipTypeEnum } from "./components/PolyLookupControl";
+import PolyLookupControl, { PolyLookupProps, RelationshipTypeEnum, TagAction } from "./components/PolyLookupControl";
 import { IInputs, IOutputs } from "./generated/ManifestTypes";
 import { IExtendedContext } from "./types/extendedContext";
 import { LanguagePack } from "./types/languagePack";
@@ -73,6 +73,9 @@ export class PolyLookup implements ComponentFramework.ReactControl<IInputs, IOut
       disabled: context.mode.isControlDisabled,
       formType: typeof Xrm === "undefined" ? undefined : Xrm.Page.ui.getFormType(),
       outputSelectedItems: !!context.parameters.outputField?.attributes?.LogicalName,
+      tagAction: context.parameters.tagAction?.raw
+        ? (Number.parseInt(context.parameters.tagAction.raw) as TagAction)
+        : undefined,
       defaultLanguagePack: this.languagePack,
       languagePackPath: context.parameters.languagePackPath?.raw ?? undefined,
       onChange:

--- a/PolyLookupComponent/package.json
+++ b/PolyLookupComponent/package.json
@@ -8,7 +8,7 @@
     "lint": "pcf-scripts lint",
     "lint:fix": "pcf-scripts lint fix",
     "rebuild": "pcf-scripts rebuild",
-    "start": "pcf-scripts start",
+    "start": "pcf-scripts start watch",
     "refreshTypes": "pcf-scripts refreshTypes"
   },
   "dependencies": {

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The components included in this repository are fully documented with examples an
 
 1. **[PolyLookup](https://github.com/khoait/DCE.PCF/wiki/PolyLookup)**: Multi-select lookup supporting different types of many-to-many relationships.
 2. **[Lookdown](https://github.com/khoait/DCE.PCF/wiki/Lookdown)**: Lookup field as a dropdown with advanced features.
+3. **[TimePicker](https://github.com/khoait/DCE.PCF/wiki/TimePicker)**: TimePicker only displays the time part of a datetime field and supports quick values from a dropdown.
 
 ## ⚙️ Installation
 
@@ -74,4 +75,4 @@ when you're ready, you can build a solution package that contains all components
    ```
    msbuild /t:build /restore /p:configuration=Release
    ```
-3. you can find an managed solution and an unmanaged solution will be created in the output folder under `solution/bin/Release`
+3. you can find a managed solution and an unmanaged solution created in the output folder under `solution/bin/Release`

--- a/solution/solution.cdsproj
+++ b/solution/solution.cdsproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PolyLookupComponent\PolyLookupComponent.pcfproj" />
     <ProjectReference Include="..\LookdownComponent\LookdownComponent.pcfproj" />
+    <ProjectReference Include="..\TimePickerComponent\TimePickerComponent.pcfproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />

--- a/solution/src/Other/Solution.xml
+++ b/solution/src/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="DCE PCF Components" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.5.0</Version>
+    <Version>1.0.6.0</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>
@@ -20,10 +20,10 @@
       </LocalizedNames>
       <Descriptions>
         <!-- Description of Cds Publisher in language code -->
-        <Description description="DynamicsCrmExp PCF Components Library.&#xA;- PolyLookup v1.3.0&#xA;- Lookdown v1.2.0&#xA;&#xA;For documentation and configuration, please visit: https://github.com/khoait/DCE.PCF/wiki&#xA;&#xA;For feedback and report issues, please visit: https://github.com/khoait/DCE.PCF/issues" languagecode="1033" />
+        <Description description="DynamicsCrmExp PCF Components Library.&#xA;- PolyLookup v1.4.0&#xA;- Lookdown v1.2.0&#xA;- TimePicker v1.0.0&#xA;&#xA;For documentation and configuration, please visit: https://github.com/khoait/DCE.PCF/wiki&#xA;&#xA;For feedback and report issues, please visit: https://github.com/khoait/DCE.PCF/issues" languagecode="1033" />
       </Descriptions>
       <EMailAddress xsi:nil="true"></EMailAddress>
-      <SupportingWebsiteUrl xsi:nil="true"></SupportingWebsiteUrl>
+      <SupportingWebsiteUrl xsi:nil="true">https://github.com/khoait/DCE.PCF/issues</SupportingWebsiteUrl>
       <!-- Customization Prefix for the Cds Publisher-->
       <CustomizationPrefix>dce</CustomizationPrefix>
       <!-- Derived Option Value Prefix for the Customization Prefix of Cds Publisher -->


### PR DESCRIPTION
### Previous Behavior
- Clicking on a selected tag does nothing.

### New Behavior
- a new `tagAction` prop is introduced with options to open a record form inline or as dialog when a selected tag is clicked.

### Related Issue(s)
- #106 
