### PR TITLE
Enhanced Search Functionality. Wildcards can now be used to search for words that match unknown characters.

### DIFF
--- a/PolyLookupComponent/PolyLookup/components/PolyLookupControl.tsx
+++ b/PolyLookupComponent/PolyLookup/components/PolyLookupControl.tsx
@@ -1,28 +1,28 @@
 import {
-  ActionButton,
-  IBasePickerStyles,
-  IBasePickerSuggestionsProps,
-  ITag,
-  ITagItemProps,
-  TagItem,
-  TagPicker,
-  TagPickerBase,
-  ValidationState,
+    ActionButton,
+    IBasePickerStyles,
+    IBasePickerSuggestionsProps,
+    ITag,
+    ITagItemProps,
+    TagItem,
+    TagPicker,
+    TagPickerBase,
+    ValidationState,
 } from "@fluentui/react";
 import { QueryClient, QueryClientProvider, useMutation } from "@tanstack/react-query";
 import Handlebars from "handlebars";
 import React, { useCallback } from "react";
 import { sprintf } from "sprintf-js";
 import {
-  associateRecord,
-  createRecord,
-  deleteRecord,
-  disassociateRecord,
-  getCurrentRecord,
-  retrieveMultipleFetch,
-  useLanguagePack,
-  useMetadata,
-  useSelectedItems,
+    associateRecord,
+    createRecord,
+    deleteRecord,
+    disassociateRecord,
+    getCurrentRecord,
+    retrieveMultipleFetch,
+    useLanguagePack,
+    useMetadata,
+    useSelectedItems,
 } from "../services/DataverseService";
 import { LanguagePack } from "../types/languagePack";
 import { IMetadata } from "../types/metadata";
@@ -33,562 +33,580 @@ const parser = new DOMParser();
 const serializer = new XMLSerializer();
 
 export enum RelationshipTypeEnum {
-  ManyToMany,
-  Custom,
-  Connection,
+    ManyToMany,
+    Custom,
+    Connection,
 }
 
 export enum TagAction {
-  None = 0,
-  OpenInline = 1,
-  OpenDialog = 2,
-  OpenInlineIntersect = 3,
-  OpenDialogIntersect = 4,
+    None = 0,
+    OpenInline = 1,
+    OpenDialog = 2,
+    OpenInlineIntersect = 3,
+    OpenDialogIntersect = 4,
 }
 
 export interface PolyLookupProps {
-  currentTable: string;
-  currentRecordId: string;
-  relationshipName: string;
-  relationship2Name?: string;
-  relationshipType: RelationshipTypeEnum;
-  clientUrl: string;
-  lookupView?: string;
-  itemLimit?: number;
-  pageSize?: number;
-  disabled?: boolean;
-  formType?: XrmEnum.FormType;
-  outputSelectedItems?: boolean;
-  tagAction?: TagAction;
-  defaultLanguagePack: LanguagePack;
-  languagePackPath?: string;
-  onChange?: (selectedItems: ComponentFramework.EntityReference[] | undefined) => void;
-  onQuickCreate?: (
-    entityName: string | undefined,
-    primaryAttribute: string | undefined,
-    value: string | undefined,
-    useQuickCreateForm: boolean | undefined
-  ) => Promise<string | undefined>;
+    currentTable: string;
+    currentRecordId: string;
+    relationshipName: string;
+    relationship2Name?: string;
+    relationshipType: RelationshipTypeEnum;
+    clientUrl: string;
+    lookupView?: string;
+    itemLimit?: number;
+    pageSize?: number;
+    disabled?: boolean;
+    formType?: XrmEnum.FormType;
+    outputSelectedItems?: boolean;
+    tagAction?: TagAction;
+    defaultLanguagePack: LanguagePack;
+    languagePackPath?: string;
+    onChange?: (selectedItems: ComponentFramework.EntityReference[] | undefined) => void;
+    onQuickCreate?: (
+        entityName: string | undefined,
+        primaryAttribute: string | undefined,
+        value: string | undefined,
+        useQuickCreateForm: boolean | undefined
+    ) => Promise<string | undefined>;
 }
 
 interface ITagWithData extends ITag {
-  data: ComponentFramework.WebApi.Entity;
+    data: ComponentFramework.WebApi.Entity;
 }
 
 const Body = ({
-  currentTable,
-  currentRecordId,
-  relationshipName,
-  relationship2Name,
-  relationshipType,
-  clientUrl,
-  lookupView,
-  itemLimit,
-  pageSize,
-  disabled,
-  formType,
-  outputSelectedItems,
-  tagAction,
-  defaultLanguagePack,
-  languagePackPath,
-  onChange,
-  onQuickCreate,
-}: PolyLookupProps) => {
-  const [selectedItemsCreate, setSelectedItemsCreate] = React.useState<ComponentFramework.WebApi.Entity[]>([]);
-
-  const pickerRef = React.useRef<TagPickerBase>(null);
-
-  const { data: loadedLanguagePack } = useLanguagePack(languagePackPath, defaultLanguagePack);
-
-  const languagePack = loadedLanguagePack ?? defaultLanguagePack;
-
-  const pickerSuggestionsProps: IBasePickerSuggestionsProps = {
-    suggestionsHeaderText: languagePack.SuggestionListHeaderDefaultLabel,
-    noResultsFoundText: languagePack.EmptyListDefaultMessage,
-    forceResolveText: languagePack.AddNewLabel,
-    showForceResolve: () => onQuickCreate !== undefined,
-    resultsFooter: () => <div>{languagePack.NoMoreRecordsMessage}</div>,
-    resultsFooterFull: () => <div>{languagePack.SuggestionListFullMessage}</div>,
-    resultsMaximumNumber: (pageSize ?? 50) * 2,
-    searchForMoreText: languagePack.LoadMoreLabel,
-  };
-
-  const getPlaceholder = () => {
-    if (formType === XrmEnum.FormType.Create) {
-      if (!outputSelectedItems) {
-        return languagePack.CreateFormNotSupportedMessage;
-      }
-    } else if (formType !== XrmEnum.FormType.Update) {
-      return languagePack.ControlIsNotAvailableMessage;
-    }
-
-    if (isDataLoading) {
-      return languagePack.LoadingMessage;
-    }
-
-    if (selectedItems?.length || selectedItemsCreate.length || disabled) {
-      return "";
-    }
-
-    return metadata?.associatedEntity.DisplayCollectionNameLocalized
-      ? sprintf(languagePack.Placeholder, metadata?.associatedEntity.DisplayCollectionNameLocalized)
-      : languagePack.PlaceholderDefault;
-  };
-
-  const shouldDisable = () => {
-    if (formType === XrmEnum.FormType.Create) {
-      if (!outputSelectedItems) {
-        return true;
-      }
-    } else if (formType !== XrmEnum.FormType.Update) {
-      return true;
-    }
-    return false;
-  };
-
-  const {
-    data: metadata,
-    isLoading: isLoadingMetadata,
-    isSuccess: isLoadingMetadataSuccess,
-  } = useMetadata(
     currentTable,
+    currentRecordId,
     relationshipName,
-    relationshipType === RelationshipTypeEnum.Custom || relationshipType === RelationshipTypeEnum.Connection
-      ? relationship2Name
-      : undefined,
-    lookupView
-  );
+    relationship2Name,
+    relationshipType,
+    clientUrl,
+    lookupView,
+    itemLimit,
+    pageSize,
+    disabled,
+    formType,
+    outputSelectedItems,
+    tagAction,
+    defaultLanguagePack,
+    languagePackPath,
+    onChange,
+    onQuickCreate,
+}: PolyLookupProps) => {
+    const [selectedItemsCreate, setSelectedItemsCreate] = React.useState<ComponentFramework.WebApi.Entity[]>([]);
 
-  if (metadata && isLoadingMetadataSuccess) {
-    pickerSuggestionsProps.suggestionsHeaderText = metadata.associatedEntity.DisplayCollectionNameLocalized
-      ? sprintf(languagePack.SuggestionListHeaderLabel, metadata.associatedEntity.DisplayCollectionNameLocalized)
-      : languagePack.SuggestionListHeaderDefaultLabel;
+    const pickerRef = React.useRef<TagPickerBase>(null);
 
-    pickerSuggestionsProps.noResultsFoundText = metadata.associatedEntity.DisplayCollectionNameLocalized
-      ? sprintf(languagePack.EmptyListMessage, metadata.associatedEntity.DisplayCollectionNameLocalized)
-      : languagePack.EmptyListDefaultMessage;
-  }
+    const { data: loadedLanguagePack } = useLanguagePack(languagePackPath, defaultLanguagePack);
 
-  const associatedTableSetName = metadata?.associatedEntity.EntitySetName ?? "";
-  const associatedFetchXml = metadata?.associatedView.fetchxml;
+    const languagePack = loadedLanguagePack ?? defaultLanguagePack;
 
-  const fetchXmlTemplate = Handlebars.compile(associatedFetchXml ?? "");
+    const pickerSuggestionsProps: IBasePickerSuggestionsProps = {
+        suggestionsHeaderText: languagePack.SuggestionListHeaderDefaultLabel,
+        noResultsFoundText: languagePack.EmptyListDefaultMessage,
+        forceResolveText: languagePack.AddNewLabel,
+        showForceResolve: () => onQuickCreate !== undefined,
+        resultsFooter: () => <div>{languagePack.NoMoreRecordsMessage}</div>,
+        resultsFooterFull: () => <div>{languagePack.SuggestionListFullMessage}</div>,
+        resultsMaximumNumber: (pageSize ?? 50) * 2,
+        searchForMoreText: languagePack.LoadMoreLabel,
+    };
 
-  // get selected items
-  const {
-    data: selectedItems,
-    isInitialLoading: isLoadingSelectedItems,
-    isSuccess: isLoadingSelectedItemsSuccess,
-    refetch: selectedItemsRefetch,
-  } = useSelectedItems(metadata, currentRecordId, formType);
+    const getPlaceholder = () => {
+        if (formType === XrmEnum.FormType.Create) {
+            if (!outputSelectedItems) {
+                return languagePack.CreateFormNotSupportedMessage;
+            }
+        } else if (formType !== XrmEnum.FormType.Update) {
+            return languagePack.ControlIsNotAvailableMessage;
+        }
 
-  if (isLoadingSelectedItemsSuccess && onChange) {
-    onChange(
-      selectedItems?.map((i) => {
-        return {
-          id: i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""],
-          name: i[metadata?.associatedEntity.PrimaryNameAttribute ?? ""],
-          etn: metadata?.associatedEntity.LogicalName ?? "",
-        } as ComponentFramework.EntityReference;
-      })
+        if (isDataLoading) {
+            return languagePack.LoadingMessage;
+        }
+
+        if (selectedItems?.length || selectedItemsCreate.length || disabled) {
+            return "";
+        }
+
+        return metadata?.associatedEntity.DisplayCollectionNameLocalized
+            ? sprintf(languagePack.Placeholder, metadata?.associatedEntity.DisplayCollectionNameLocalized)
+            : languagePack.PlaceholderDefault;
+    };
+
+    const shouldDisable = () => {
+        if (formType === XrmEnum.FormType.Create) {
+            if (!outputSelectedItems) {
+                return true;
+            }
+        } else if (formType !== XrmEnum.FormType.Update) {
+            return true;
+        }
+        return false;
+    };
+
+    const {
+        data: metadata,
+        isLoading: isLoadingMetadata,
+        isSuccess: isLoadingMetadataSuccess,
+    } = useMetadata(
+        currentTable,
+        relationshipName,
+        relationshipType === RelationshipTypeEnum.Custom || relationshipType === RelationshipTypeEnum.Connection
+            ? relationship2Name
+            : undefined,
+        lookupView
     );
-  }
 
-  // filter query
-  const filterQuery = useMutation({
-    mutationFn: ({ searchText, pageSizeParam }: { searchText: string; pageSizeParam: number | undefined }) => {
-      let fetchXml = metadata?.associatedView.fetchxml ?? "";
-      let shouldDefaultSearch = false;
-      if (!lookupView && metadata?.associatedView.querytype === 64) {
-        shouldDefaultSearch = true;
-      } else {
-        if (
-          !fetchXml.includes("{{PolyLookupSearch}}") &&
-          !fetchXml.includes("{{ PolyLookupSearch}}") &&
-          !fetchXml.includes("{{PolyLookupSearch }}") &&
-          !fetchXml.includes("{{ PolyLookupSearch }}")
-        ) {
-          shouldDefaultSearch = true;
-        }
+    if (metadata && isLoadingMetadataSuccess) {
+        pickerSuggestionsProps.suggestionsHeaderText = metadata.associatedEntity.DisplayCollectionNameLocalized
+            ? sprintf(languagePack.SuggestionListHeaderLabel, metadata.associatedEntity.DisplayCollectionNameLocalized)
+            : languagePack.SuggestionListHeaderDefaultLabel;
 
-        const currentRecord = getCurrentRecord();
+        pickerSuggestionsProps.noResultsFoundText = metadata.associatedEntity.DisplayCollectionNameLocalized
+            ? sprintf(languagePack.EmptyListMessage, metadata.associatedEntity.DisplayCollectionNameLocalized)
+            : languagePack.EmptyListDefaultMessage;
+    }
 
-        fetchXml = fetchXmlTemplate({
-          ...currentRecord,
-          PolyLookupSearch: searchText,
-        });
-      }
+    const associatedTableSetName = metadata?.associatedEntity.EntitySetName ?? "";
+    const associatedFetchXml = metadata?.associatedView.fetchxml;
 
-      if (shouldDefaultSearch) {
-        // if lookup view is not specified and using default lookup fiew,
-        // add filter condition to fetchxml to support search
-        const doc = parser.parseFromString(fetchXml, "application/xml");
-        const entities = doc.documentElement.getElementsByTagName("entity");
-        for (let i = 0; i < entities.length; i++) {
-          const entity = entities[i];
-          if (entity.getAttribute("name") === metadata?.associatedEntity.LogicalName) {
-            const filter = doc.createElement("filter");
-            const condition = doc.createElement("condition");
-            condition.setAttribute("attribute", metadata?.associatedEntity.PrimaryNameAttribute ?? "");
-            condition.setAttribute("operator", "like");
-            condition.setAttribute("value", `%${searchText}%`);
-            filter.appendChild(condition);
-            entity.appendChild(filter);
-          }
-        }
-        fetchXml = serializer.serializeToString(doc);
-      }
+    const fetchXmlTemplate = Handlebars.compile(associatedFetchXml ?? "");
 
-      return retrieveMultipleFetch(associatedTableSetName, fetchXml, 1, pageSizeParam);
-    },
-  });
+    // get selected items
+    const {
+        data: selectedItems,
+        isInitialLoading: isLoadingSelectedItems,
+        isSuccess: isLoadingSelectedItemsSuccess,
+        refetch: selectedItemsRefetch,
+    } = useSelectedItems(metadata, currentRecordId, formType);
 
-  // associate query
-  const associateQuery = useMutation({
-    mutationFn: (id: string) => {
-      if (relationshipType === RelationshipTypeEnum.ManyToMany) {
-        return associateRecord(
-          metadata?.currentEntity.EntitySetName,
-          currentRecordId,
-          metadata?.associatedEntity?.EntitySetName,
-          id,
-          relationshipName,
-          clientUrl
-        );
-      } else if (
-        relationshipType === RelationshipTypeEnum.Custom ||
-        relationshipType === RelationshipTypeEnum.Connection
-      ) {
-        return createRecord(metadata?.intersectEntity.EntitySetName, {
-          [`${metadata?.currentEntityNavigationPropertyName}@odata.bind`]: `/${metadata?.currentEntity.EntitySetName}(${currentRecordId})`,
-          [`${metadata?.associatedEntityNavigationPropertyName}@odata.bind`]: `/${metadata?.associatedEntity.EntitySetName}(${id})`,
-        });
-      }
-      return Promise.reject(languagePack.RelationshipNotSupportedMessage);
-    },
-    onSuccess: (data, variables, context) => {
-      selectedItemsRefetch();
-    },
-  });
-
-  // disassociate query
-  const disassociateQuery = useMutation({
-    mutationFn: (id: string) => {
-      if (relationshipType === RelationshipTypeEnum.ManyToMany) {
-        return disassociateRecord(metadata?.currentEntity?.EntitySetName, currentRecordId, relationshipName, id);
-      } else if (
-        relationshipType === RelationshipTypeEnum.Custom ||
-        relationshipType === RelationshipTypeEnum.Connection
-      ) {
-        return deleteRecord(metadata?.intersectEntity.EntitySetName, id);
-      }
-      return Promise.reject(languagePack.RelationshipNotSupportedMessage);
-    },
-    onSuccess: (data, variables, context) => {
-      selectedItemsRefetch();
-    },
-  });
-
-  const filterSuggestions = useCallback(
-    async (filterText: string, selectedTag?: ITag[]): Promise<ITag[]> => {
-      const results = await filterQuery.mutateAsync({ searchText: filterText, pageSizeParam: pageSize });
-      return getSuggestionTags(results, metadata);
-    },
-    [metadata?.associatedEntity.EntitySetName]
-  );
-
-  const showMoreSuggestions = useCallback(
-    async (filterText: string, selectedTag?: ITag[]): Promise<ITag[]> => {
-      const results = await filterQuery.mutateAsync({
-        searchText: filterText,
-        pageSizeParam: (pageSize ?? 50) * 2 + 1,
-      });
-      return getSuggestionTags(results, metadata);
-    },
-    [metadata?.associatedEntity.EntitySetName]
-  );
-
-  const showAllSuggestions = useCallback(
-    async (selectedTags?: ITag[]): Promise<ITag[]> => {
-      const results = await filterQuery.mutateAsync({ searchText: "", pageSizeParam: pageSize });
-      return getSuggestionTags(results, metadata);
-    },
-    [metadata?.associatedEntity.PrimaryIdAttribute]
-  );
-
-  const onPickerChange = useCallback(
-    (selectedTags?: ITag[]): void => {
-      if (formType === XrmEnum.FormType.Create) {
-        const removed = selectedItemsCreate?.filter(
-          (i) =>
-            !selectedTags?.some((t) => {
-              const data = (t as ITagWithData).data;
-              return (
-                data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
-                i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
-              );
+    if (isLoadingSelectedItemsSuccess && onChange) {
+        onChange(
+            selectedItems?.map((i) => {
+                return {
+                    id: i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""],
+                    name: i[metadata?.associatedEntity.PrimaryNameAttribute ?? ""],
+                    etn: metadata?.associatedEntity.LogicalName ?? "",
+                } as ComponentFramework.EntityReference;
             })
         );
+    }
 
-        const added = selectedTags
-          ?.filter((t) => {
-            const data = (t as ITagWithData).data;
-            return !selectedItemsCreate?.some(
-              (i) =>
-                i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
-                data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
-            );
-          })
-          .map((t) => (t as ITagWithData).data);
+    // filter query
+    const filterQuery = useMutation({
+        mutationFn: ({ searchText, pageSizeParam }: { searchText: string; pageSizeParam: number | undefined }) => {
+            let fetchXml = metadata?.associatedView.fetchxml ?? "";
+            let shouldDefaultSearch = false;
+            if (!lookupView && metadata?.associatedView.querytype === 64) {
+                shouldDefaultSearch = true;
+            } else {
+                if (
+                    !fetchXml.includes("{{PolyLookupSearch}}") &&
+                    !fetchXml.includes("{{ PolyLookupSearch}}") &&
+                    !fetchXml.includes("{{PolyLookupSearch }}") &&
+                    !fetchXml.includes("{{ PolyLookupSearch }}")
+                ) {
+                    shouldDefaultSearch = true;
+                }
 
-        const oldRemoved = selectedItemsCreate?.filter(
-          (o) =>
-            !removed?.some(
-              (r) =>
-                r[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
-                o[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
-            )
-        );
+                const currentRecord = getCurrentRecord();
 
-        const newSelectedItems = [...oldRemoved, ...(added ?? [])];
-        setSelectedItemsCreate(newSelectedItems);
+                fetchXml = fetchXmlTemplate({
+                    ...currentRecord,
+                    PolyLookupSearch: searchText,
+                });
+            }
 
-        if (onChange) {
-          onChange(
-            newSelectedItems?.map((i) => {
-              return {
-                id: i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""],
-                name: i[metadata?.associatedEntity.PrimaryNameAttribute ?? ""],
-                etn: metadata?.associatedEntity.LogicalName ?? "",
-              } as ComponentFramework.EntityReference;
-            })
-          );
-        }
-      } else if (formType === XrmEnum.FormType.Update) {
-        const removed = selectedItems
-          ?.filter(
-            (i) =>
-              !selectedTags?.some((t) => {
-                const data = (t as ITagWithData).data;
-                return (
-                  data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
-                  i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+            if (shouldDefaultSearch) {
+                // if lookup view is not specified and using default lookup fiew,
+                // add filter condition to fetchxml to support search
+                const doc = parser.parseFromString(fetchXml, "application/xml");
+                const entities = doc.documentElement.getElementsByTagName("entity");
+                for (let i = 0; i < entities.length; i++) {
+                    const entity = entities[i];
+                    if (entity.getAttribute("name") === metadata?.associatedEntity.LogicalName) {
+                        const filter = doc.createElement("filter");
+                        const condition = doc.createElement("condition");
+                        condition.setAttribute("attribute", metadata?.associatedEntity.PrimaryNameAttribute ?? "");
+                        if (searchText.includes("*")) {
+                            const beginsWithWildCard = searchText.startsWith("*") ? true : false;
+                            const endsWithWildCard = searchText.endsWith("*") ? true : false;
+                            if (beginsWithWildCard || endsWithWildCard) {
+                                if (beginsWithWildCard) {
+                                    searchText = searchText.replace("*", "");
+                                }
+                                if (endsWithWildCard) {
+                                    searchText = searchText.substring(0, searchText.length - 1);
+                                }
+                                searchText = "%" + searchText + "%";
+                            }
+                            searchText = searchText.split("*").join("%");
+                            condition.setAttribute("operator", "like");
+                            condition.setAttribute("value", `${searchText}`);
+                        }
+                        else {
+                            condition.setAttribute("operator", "begins-with");
+                            condition.setAttribute("value", `${searchText}`);
+                        }
+                        filter.appendChild(condition);
+                        entity.appendChild(filter);
+                    }
+                }
+                fetchXml = serializer.serializeToString(doc);
+            }
+
+            return retrieveMultipleFetch(associatedTableSetName, fetchXml, 1, pageSizeParam);
+        },
+    });
+
+    // associate query
+    const associateQuery = useMutation({
+        mutationFn: (id: string) => {
+            if (relationshipType === RelationshipTypeEnum.ManyToMany) {
+                return associateRecord(
+                    metadata?.currentEntity.EntitySetName,
+                    currentRecordId,
+                    metadata?.associatedEntity?.EntitySetName,
+                    id,
+                    relationshipName,
+                    clientUrl
                 );
-              })
-          )
-          .map((i) =>
-            relationshipType === RelationshipTypeEnum.ManyToMany
-              ? i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
-              : i[metadata?.intersectEntity.PrimaryIdAttribute ?? ""]
-          );
+            } else if (
+                relationshipType === RelationshipTypeEnum.Custom ||
+                relationshipType === RelationshipTypeEnum.Connection
+            ) {
+                return createRecord(metadata?.intersectEntity.EntitySetName, {
+                    [`${metadata?.currentEntityNavigationPropertyName}@odata.bind`]: `/${metadata?.currentEntity.EntitySetName}(${currentRecordId})`,
+                    [`${metadata?.associatedEntityNavigationPropertyName}@odata.bind`]: `/${metadata?.associatedEntity.EntitySetName}(${id})`,
+                });
+            }
+            return Promise.reject(languagePack.RelationshipNotSupportedMessage);
+        },
+        onSuccess: (data, variables, context) => {
+            selectedItemsRefetch();
+        },
+    });
 
-        const added = selectedTags
-          ?.filter((t) => {
-            const data = (t as ITagWithData).data;
-            return !selectedItems?.some(
-              (i) =>
-                i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
-                data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
-            );
-          })
-          .map((t) => t.key);
+    // disassociate query
+    const disassociateQuery = useMutation({
+        mutationFn: (id: string) => {
+            if (relationshipType === RelationshipTypeEnum.ManyToMany) {
+                return disassociateRecord(metadata?.currentEntity?.EntitySetName, currentRecordId, relationshipName, id);
+            } else if (
+                relationshipType === RelationshipTypeEnum.Custom ||
+                relationshipType === RelationshipTypeEnum.Connection
+            ) {
+                return deleteRecord(metadata?.intersectEntity.EntitySetName, id);
+            }
+            return Promise.reject(languagePack.RelationshipNotSupportedMessage);
+        },
+        onSuccess: (data, variables, context) => {
+            selectedItemsRefetch();
+        },
+    });
 
-        added?.forEach((id) => associateQuery.mutate(id as string));
-        removed?.forEach((id) => disassociateQuery.mutate(id as string));
-      }
-    },
-    [selectedItems, selectedItemsCreate, metadata?.associatedEntity.PrimaryIdAttribute]
-  );
-
-  const onItemSelected = useCallback(
-    (item?: ITag): ITag | null => {
-      if (!item) return null;
-
-      if (
-        formType === XrmEnum.FormType.Create &&
-        !selectedItemsCreate?.some((i) => i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] === item.key)
-      ) {
-        return item;
-      } else if (
-        formType === XrmEnum.FormType.Update &&
-        !selectedItems?.some((i) => i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] === item.key)
-      ) {
-        return item;
-      }
-      return null;
-    },
-    [selectedItems, metadata?.associatedEntity.PrimaryIdAttribute]
-  );
-
-  const onCreateNew = (input: string): ValidationState => {
-    if (onQuickCreate) {
-      onQuickCreate(
-        metadata?.associatedEntity.LogicalName,
-        metadata?.associatedEntity.PrimaryNameAttribute,
-        input,
-        metadata?.associatedEntity.IsQuickCreateEnabled
-      )
-        .then((result) => {
-          if (result) {
-            associateQuery.mutate(result);
-            // TODO: fix this hack
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            pickerRef.current.input.current?._updateValue("");
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    }
-    return ValidationState.invalid;
-  };
-
-  const onTagClick = async (item: ITagWithData) => {
-    if (!tagAction) return;
-    if (!metadata?.associatedEntity) return;
-
-    let targetEntity = metadata?.associatedEntity.LogicalName;
-    let targetId = item.key as string;
-
-    if (
-      (relationshipType === RelationshipTypeEnum.Custom || relationshipType === RelationshipTypeEnum.Connection) &&
-      (tagAction === TagAction.OpenDialogIntersect || tagAction === TagAction.OpenInlineIntersect)
-    ) {
-      targetEntity = metadata.intersectEntity.LogicalName;
-      targetId = item.data[metadata?.intersectEntity.PrimaryIdAttribute];
-    }
-
-    await Xrm.Navigation.navigateTo(
-      {
-        pageType: "entityrecord",
-        entityName: targetEntity,
-        entityId: targetId,
-      },
-      { target: tagAction === TagAction.OpenDialog || tagAction === TagAction.OpenDialogIntersect ? 2 : 1 }
+    const filterSuggestions = useCallback(
+        async (filterText: string, selectedTag?: ITag[]): Promise<ITag[]> => {
+            const results = await filterQuery.mutateAsync({ searchText: filterText, pageSizeParam: pageSize });
+            return getSuggestionTags(results, metadata);
+        },
+        [metadata?.associatedEntity.EntitySetName]
     );
 
-    if (tagAction === TagAction.OpenDialog || tagAction === TagAction.OpenDialogIntersect) {
-      selectedItemsRefetch();
-    }
-  };
+    const showMoreSuggestions = useCallback(
+        async (filterText: string, selectedTag?: ITag[]): Promise<ITag[]> => {
+            const results = await filterQuery.mutateAsync({
+                searchText: filterText,
+                pageSizeParam: (pageSize ?? 50) * 2 + 1,
+            });
+            return getSuggestionTags(results, metadata);
+        },
+        [metadata?.associatedEntity.EntitySetName]
+    );
 
-  const isDataLoading = (isLoadingMetadata || isLoadingSelectedItems) && !shouldDisable();
+    const showAllSuggestions = useCallback(
+        async (selectedTags?: ITag[]): Promise<ITag[]> => {
+            const results = await filterQuery.mutateAsync({ searchText: "", pageSizeParam: pageSize });
+            return getSuggestionTags(results, metadata);
+        },
+        [metadata?.associatedEntity.PrimaryIdAttribute]
+    );
 
-  return (
-    <TagPicker
-      ref={pickerRef}
-      selectedItems={getSuggestionTags(
-        formType === XrmEnum.FormType.Create ? selectedItemsCreate : selectedItems,
-        metadata
-      )}
-      onResolveSuggestions={filterSuggestions}
-      onEmptyResolveSuggestions={showAllSuggestions}
-      onGetMoreResults={showMoreSuggestions}
-      onChange={onPickerChange}
-      onItemSelected={onItemSelected}
-      styles={({ isFocused }) => {
-        // eslint-disable-next-line react/prop-types
-        const pickerStyles: Partial<IBasePickerStyles> = {
-          root: { backgroundColor: "#fff", width: "100%" },
-          input: { minWidth: "0", display: disabled ? "none" : "inline-block" },
-          text: {
-            minWidth: "0",
-            borderColor: "transparent",
-            borderWidth: 1,
-            borderRadius: 1,
-            "&:after": {
-              backgroundColor: "transparent",
-              borderColor: isFocused ? "#666" : "transparent",
-              borderWidth: 1,
-              borderRadius: 1,
+    const onPickerChange = useCallback(
+        (selectedTags?: ITag[]): void => {
+            if (formType === XrmEnum.FormType.Create) {
+                const removed = selectedItemsCreate?.filter(
+                    (i) =>
+                        !selectedTags?.some((t) => {
+                            const data = (t as ITagWithData).data;
+                            return (
+                                data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
+                                i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+                            );
+                        })
+                );
+
+                const added = selectedTags
+                    ?.filter((t) => {
+                        const data = (t as ITagWithData).data;
+                        return !selectedItemsCreate?.some(
+                            (i) =>
+                                i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
+                                data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+                        );
+                    })
+                    .map((t) => (t as ITagWithData).data);
+
+                const oldRemoved = selectedItemsCreate?.filter(
+                    (o) =>
+                        !removed?.some(
+                            (r) =>
+                                r[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
+                                o[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+                        )
+                );
+
+                const newSelectedItems = [...oldRemoved, ...(added ?? [])];
+                setSelectedItemsCreate(newSelectedItems);
+
+                if (onChange) {
+                    onChange(
+                        newSelectedItems?.map((i) => {
+                            return {
+                                id: i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""],
+                                name: i[metadata?.associatedEntity.PrimaryNameAttribute ?? ""],
+                                etn: metadata?.associatedEntity.LogicalName ?? "",
+                            } as ComponentFramework.EntityReference;
+                        })
+                    );
+                }
+            } else if (formType === XrmEnum.FormType.Update) {
+                const removed = selectedItems
+                    ?.filter(
+                        (i) =>
+                            !selectedTags?.some((t) => {
+                                const data = (t as ITagWithData).data;
+                                return (
+                                    data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
+                                    i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+                                );
+                            })
+                    )
+                    .map((i) =>
+                        relationshipType === RelationshipTypeEnum.ManyToMany
+                            ? i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+                            : i[metadata?.intersectEntity.PrimaryIdAttribute ?? ""]
+                    );
+
+                const added = selectedTags
+                    ?.filter((t) => {
+                        const data = (t as ITagWithData).data;
+                        return !selectedItems?.some(
+                            (i) =>
+                                i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ===
+                                data[metadata?.associatedEntity.PrimaryIdAttribute ?? ""]
+                        );
+                    })
+                    .map((t) => t.key);
+
+                added?.forEach((id) => associateQuery.mutate(id as string));
+                removed?.forEach((id) => disassociateQuery.mutate(id as string));
+            }
+        },
+        [selectedItems, selectedItemsCreate, metadata?.associatedEntity.PrimaryIdAttribute]
+    );
+
+    const onItemSelected = useCallback(
+        (item?: ITag): ITag | null => {
+            if (!item) return null;
+
+            if (
+                formType === XrmEnum.FormType.Create &&
+                !selectedItemsCreate?.some((i) => i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] === item.key)
+            ) {
+                return item;
+            } else if (
+                formType === XrmEnum.FormType.Update &&
+                !selectedItems?.some((i) => i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] === item.key)
+            ) {
+                return item;
+            }
+            return null;
+        },
+        [selectedItems, metadata?.associatedEntity.PrimaryIdAttribute]
+    );
+
+    const onCreateNew = (input: string): ValidationState => {
+        if (onQuickCreate) {
+            onQuickCreate(
+                metadata?.associatedEntity.LogicalName,
+                metadata?.associatedEntity.PrimaryNameAttribute,
+                input,
+                metadata?.associatedEntity.IsQuickCreateEnabled
+            )
+                .then((result) => {
+                    if (result) {
+                        associateQuery.mutate(result);
+                        // TODO: fix this hack
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        pickerRef.current.input.current?._updateValue("");
+                    }
+                })
+                .catch((err) => {
+                    console.log(err);
+                });
+        }
+        return ValidationState.invalid;
+    };
+
+    const onTagClick = async (item: ITagWithData) => {
+        if (!tagAction) return;
+        if (!metadata?.associatedEntity) return;
+
+        let targetEntity = metadata?.associatedEntity.LogicalName;
+        let targetId = item.key as string;
+
+        if (
+            (relationshipType === RelationshipTypeEnum.Custom || relationshipType === RelationshipTypeEnum.Connection) &&
+            (tagAction === TagAction.OpenDialogIntersect || tagAction === TagAction.OpenInlineIntersect)
+        ) {
+            targetEntity = metadata.intersectEntity.LogicalName;
+            targetId = item.data[metadata?.intersectEntity.PrimaryIdAttribute];
+        }
+
+        await Xrm.Navigation.navigateTo(
+            {
+                pageType: "entityrecord",
+                entityName: targetEntity,
+                entityId: targetId,
             },
-            "&:hover:after": { backgroundColor: disabled ? "rgba(50, 50, 50, 0.1)" : "transparent" },
-          },
-        };
-        return pickerStyles;
-      }}
-      pickerSuggestionsProps={pickerSuggestionsProps}
-      disabled={disabled || shouldDisable()}
-      onRenderItem={(props: ITagItemProps) => {
-        props.styles = {
-          close: [disabled && { display: "none" }],
-          root: [
-            !!tagAction && {
-              "&:focus-within button": {
-                color: "#fff",
-              },
-              "&:focus-within:hover button": {
-                color: "#fff",
-              },
-              "&:focus-within .ms-TagItem-close:hover": {
-                color: "#fff",
-                backgroundColor: "#005a9e",
-              },
-            },
-          ],
-        };
-
-        return (
-          <TagItem {...props}>
-            {tagAction ? (
-              <ActionButton
-                styles={{ root: { height: "100%" } }}
-                onClick={() => onTagClick(props.item as ITagWithData)}
-              >
-                {props.item.name}
-              </ActionButton>
-            ) : (
-              props.item.name
-            )}
-          </TagItem>
+            { target: tagAction === TagAction.OpenDialog || tagAction === TagAction.OpenDialogIntersect ? 2 : 1 }
         );
-      }}
-      onRenderSuggestionsItem={(tag: ITag) => {
-        const data = (tag as ITagWithData).data;
-        const infoMap = new Map<string, string>();
-        metadata?.associatedView?.layoutjson?.Rows?.at(0)?.Cells.forEach((cell) => {
-          let displayValue = data[cell.Name + "@OData.Community.Display.V1.FormattedValue"];
-          if (!displayValue) {
-            displayValue = data[cell.Name];
-          }
-          infoMap.set(cell.Name, displayValue ?? "");
-        });
-        return <SuggestionInfo infoMap={infoMap}></SuggestionInfo>;
-      }}
-      resolveDelay={100}
-      inputProps={{
-        placeholder: getPlaceholder(),
-      }}
-      pickerCalloutProps={{
-        calloutMaxWidth: 500,
-      }}
-      itemLimit={itemLimit}
-      onValidateInput={onCreateNew}
-    />
-  );
+
+        if (tagAction === TagAction.OpenDialog || tagAction === TagAction.OpenDialogIntersect) {
+            selectedItemsRefetch();
+        }
+    };
+
+    const isDataLoading = (isLoadingMetadata || isLoadingSelectedItems) && !shouldDisable();
+
+    return (
+        <TagPicker
+            ref={pickerRef}
+            selectedItems={getSuggestionTags(
+                formType === XrmEnum.FormType.Create ? selectedItemsCreate : selectedItems,
+                metadata
+            )}
+            onResolveSuggestions={filterSuggestions}
+            onEmptyResolveSuggestions={showAllSuggestions}
+            onGetMoreResults={showMoreSuggestions}
+            onChange={onPickerChange}
+            onItemSelected={onItemSelected}
+            styles={({ isFocused }) => {
+                // eslint-disable-next-line react/prop-types
+                const pickerStyles: Partial<IBasePickerStyles> = {
+                    root: { backgroundColor: "#fff", width: "100%" },
+                    input: { minWidth: "0", display: disabled ? "none" : "inline-block" },
+                    text: {
+                        minWidth: "0",
+                        borderColor: "transparent",
+                        borderWidth: 1,
+                        borderRadius: 1,
+                        "&:after": {
+                            backgroundColor: "transparent",
+                            borderColor: isFocused ? "#666" : "transparent",
+                            borderWidth: 1,
+                            borderRadius: 1,
+                        },
+                        "&:hover:after": { backgroundColor: disabled ? "rgba(50, 50, 50, 0.1)" : "transparent" },
+                    },
+                };
+                return pickerStyles;
+            }}
+            pickerSuggestionsProps={pickerSuggestionsProps}
+            disabled={disabled || shouldDisable()}
+            onRenderItem={(props: ITagItemProps) => {
+                props.styles = {
+                    close: [disabled && { display: "none" }],
+                    root: [
+                        !!tagAction && {
+                            "&:focus-within button": {
+                                color: "#fff",
+                            },
+                            "&:focus-within:hover button": {
+                                color: "#fff",
+                            },
+                            "&:focus-within .ms-TagItem-close:hover": {
+                                color: "#fff",
+                                backgroundColor: "#005a9e",
+                            },
+                        },
+                    ],
+                };
+
+                return (
+                    <TagItem {...props}>
+                        {tagAction ? (
+                            <ActionButton
+                                styles={{ root: { height: "100%" } }}
+                                onClick={() => onTagClick(props.item as ITagWithData)}
+                            >
+                                {props.item.name}
+                            </ActionButton>
+                        ) : (
+                            props.item.name
+                        )}
+                    </TagItem>
+                );
+            }}
+            onRenderSuggestionsItem={(tag: ITag) => {
+                const data = (tag as ITagWithData).data;
+                const infoMap = new Map<string, string>();
+                metadata?.associatedView?.layoutjson?.Rows?.at(0)?.Cells.forEach((cell) => {
+                    let displayValue = data[cell.Name + "@OData.Community.Display.V1.FormattedValue"];
+                    if (!displayValue) {
+                        displayValue = data[cell.Name];
+                    }
+                    infoMap.set(cell.Name, displayValue ?? "");
+                });
+                return <SuggestionInfo infoMap={infoMap}></SuggestionInfo>;
+            }}
+            resolveDelay={100}
+            inputProps={{
+                placeholder: getPlaceholder(),
+            }}
+            pickerCalloutProps={{
+                calloutMaxWidth: 500,
+            }}
+            itemLimit={itemLimit}
+            onValidateInput={onCreateNew}
+        />
+    );
 };
 
 function getSuggestionTags(
-  suggestions: ComponentFramework.WebApi.Entity[] | undefined,
-  metadata: IMetadata | undefined
+    suggestions: ComponentFramework.WebApi.Entity[] | undefined,
+    metadata: IMetadata | undefined
 ) {
-  return (
-    suggestions?.map(
-      (i) =>
-        ({
-          key: i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ?? "",
-          name: i[metadata?.associatedEntity.PrimaryNameAttribute ?? ""] ?? "",
-          data: i,
-        }) as ITagWithData
-    ) ?? []
-  );
+    return (
+        suggestions?.map(
+            (i) =>
+                ({
+                    key: i[metadata?.associatedEntity.PrimaryIdAttribute ?? ""] ?? "",
+                    name: i[metadata?.associatedEntity.PrimaryNameAttribute ?? ""] ?? "",
+                    data: i,
+                }) as ITagWithData
+        ) ?? []
+    );
 }
 
 export default function PolyLookupControl(props: PolyLookupProps) {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <Body {...props} />
-    </QueryClientProvider>
-  );
+    return (
+        <QueryClientProvider client={queryClient}>
+            <Body {...props} />
+        </QueryClientProvider>
+    );
 }

--- a/PolyLookupComponent/PolyLookup/components/PolyLookupControl.tsx
+++ b/PolyLookupComponent/PolyLookup/components/PolyLookupControl.tsx
@@ -242,6 +242,9 @@ const Body = ({
                                 }
                                 searchText = "%" + searchText + "%";
                             }
+                            else {
+                                searchText = searchText + "%";
+                            }
                             searchText = searchText.split("*").join("%");
                             condition.setAttribute("operator", "like");
                             condition.setAttribute("value", `${searchText}`);


### PR DESCRIPTION
### Previous Behavior
- search for records with matching search keyword entered

### New Behavior
- Wildcards can now be used to refine search and to provide better UX.
- By default, when a keyword is entered without any wildcards, records beginning with that keyword are searched.
  - E.g. "_Windows"_ matches "_Windows 11_", "_Windows 10_", "_Windows 8.1"_
- When a keyword is preceded by a wildcard, the records containing the keyword are searched.
  - E.g. "_*Windows"_ matches "_.NET Windows Forms_", "_.NET Windows Presentation_", "_Windows 11_", "_Windows 10_", "_Windows 8.1"_
- Wildcards can even be included in between the characters of keyword to match a pattern.
  - E.g. "_Wind*s"_ matches "_Windows 11_", "_Windows 10_", "_Windows 8.1"_.
  - E.g. "_*Win**s"_ matches "_.NET Windows Forms_", "_.NET Windows Presentation_", "_Windows 11_", "_Windows 10_", "_Windows 8.1"_

