### PR TITLE
refresh dropdown when dependent fields change

### DIFF
--- a/LookdownComponent/Lookdown/ControlManifest.Input.xml
+++ b/LookdownComponent/Lookdown/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="Lookdown" version="1.2.0" display-name-key="Lookdown v1.2.0" description-key="Display a lookup control as a dropdown" control-type="virtual" >
+  <control namespace="DCEPCF" constructor="Lookdown" version="1.2.1" display-name-key="Lookdown v1.2.1" description-key="Display a lookup control as a dropdown" control-type="virtual" >
     <external-service-usage enabled="false">
       <!--UNCOMMENT TO ADD EXTERNAL DOMAINS
       <domain></domain>

--- a/LookdownComponent/Lookdown/services/TemplateHelper.ts
+++ b/LookdownComponent/Lookdown/services/TemplateHelper.ts
@@ -1,0 +1,20 @@
+import Handlebars from "handlebars";
+
+/**
+ * Getting the variables from the Handlebars template.
+ * Supports helpers too.
+ * @param input
+ */
+export function getHandlebarsVariables(input: string): string[] {
+  const ast = Handlebars.parseWithoutProcessing(input);
+
+  return ast.body
+    .filter(({ type }: hbs.AST.Statement) => type === "MustacheStatement")
+    .map((statement: hbs.AST.Statement) => {
+      const moustacheStatement: hbs.AST.MustacheStatement = statement as hbs.AST.MustacheStatement;
+      const paramsExpressionList = moustacheStatement.params as hbs.AST.PathExpression[];
+      const pathExpression = moustacheStatement.path as hbs.AST.PathExpression;
+
+      return paramsExpressionList[0]?.original || pathExpression.original;
+    });
+}


### PR DESCRIPTION
### Previous Behavior
- Dropdown doesn't refresh when dependent fields change.

### New Behavior
- Dropdown should refresh and apply new filter when any of the dependent fields change.

### Related Issue(s)
- fixed #134 
