### PR TITLE
added clear button in classic look

### DIFF
--- a/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
@@ -376,9 +376,10 @@ export default function LookdownControlClassic({
           }}
         />
       </Stack.Item>
-      <Stack.Item>
+      <Stack horizontal>
+        {selectedId ? <IconButton iconProps={{ iconName: "Cancel" }} onClick={() => onChange?.(null)} /> : null}
         {hasCommand ? <IconButton iconProps={commandIcon} menuProps={menuProps} onRenderMenuIcon={() => null} /> : null}
-      </Stack.Item>
+      </Stack>
     </Stack>
   );
 }

--- a/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
@@ -35,20 +35,6 @@ const useStyle = makeStyles({
   dropdown: {
     width: "100%",
     minWidth: "0px",
-    backgroundColor: tokens.colorNeutralBackground3,
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
-    ":hover": {
-      ...shorthands.borderColor(tokens.colorTransparentStroke),
-    },
-    ":active": {
-      ...shorthands.borderColor(tokens.colorTransparentStroke),
-    },
-    ":focus": {
-      ...shorthands.borderColor(tokens.colorTransparentStroke),
-    },
-    ":focus-within": {
-      ...shorthands.borderColor(tokens.colorTransparentStroke),
-    },
   },
   optionLayout: {
     display: "flex",
@@ -311,6 +297,7 @@ export default function LookdownControlNewLook({
     <FluentProvider style={{ width: "100%" }} theme={fluentDesign?.tokenTheme}>
       <div className={styles.root}>
         <Dropdown
+          appearance="filled-darker"
           className={dropdownStyles}
           clearable
           placeholder={isError ? languagePack.LoadDataErrorMessage : "---"}

--- a/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
@@ -58,7 +58,13 @@ const useStyle = makeStyles({
     ...shorthands.gap(tokens.spacingHorizontalS),
   },
   flexFill: {
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    minWidth: 0,
+  },
+  breakWord: {
+    wordBreak: "break-word",
   },
 });
 
@@ -305,7 +311,7 @@ export default function LookdownControlNewLook({
     <FluentProvider style={{ width: "100%" }} theme={fluentDesign?.tokenTheme}>
       <div className={styles.root}>
         <Dropdown
-          className={styles.dropdown}
+          className={dropdownStyles}
           clearable
           placeholder={isError ? languagePack.LoadDataErrorMessage : "---"}
           value={isError ? "" : selectedDisplayText}
@@ -356,6 +362,7 @@ interface OptionDisplayProps {
 
 function OptionDisplay({ optionText, iconSrc, iconSize }: OptionDisplayProps) {
   const styles = useStyle();
+  const optionTextStyles = mergeClasses(styles.flexFill, styles.breakWord);
 
   return (
     <div className={styles.optionLayout}>
@@ -365,7 +372,7 @@ function OptionDisplay({ optionText, iconSrc, iconSize }: OptionDisplayProps) {
         </div>
       ) : null}
 
-      <div className={styles.flexFill}>{optionText}</div>
+      <div className={optionTextStyles}>{optionText}</div>
     </div>
   );
 }

--- a/LookdownComponent/package.json
+++ b/LookdownComponent/package.json
@@ -8,8 +8,7 @@
     "lint": "pcf-scripts lint",
     "lint:fix": "pcf-scripts lint fix",
     "rebuild": "pcf-scripts rebuild",
-    "start": "pcf-scripts start",
-    "start:watch": "pcf-scripts start watch",
+    "start": "pcf-scripts start watch",
     "refreshTypes": "pcf-scripts refreshTypes"
   },
   "dependencies": {


### PR DESCRIPTION
### Previous Behavior
- no clear button in classic look

### New Behavior
- a clear button is shown when selected value is not null

### Related Issue(s)
- fixed #146 
