### PR TITLE
fixed dynamic filtering not refreshed when dependent fields change

### DIFF
--- a/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
@@ -278,7 +278,7 @@ export default function LookdownControlClassic({
   }, []);
 
   useEffect(() => {
-    const templateVar = getHandlebarsVariables(metadata?.lookupView.fetchxml ?? "" + customFilter ?? "");
+    const templateVar = getHandlebarsVariables((metadata?.lookupView.fetchxml ?? "") + (customFilter ?? ""));
     if (templateVar.length) {
       templateVar.forEach((v) => {
         Xrm.Page.data.entity.attributes.get(v)?.addOnChange(invalidateFetchDataFn);

--- a/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
@@ -131,7 +131,7 @@ export default function LookdownControlNewLook({
   }, []);
 
   useEffect(() => {
-    const templateVar = getHandlebarsVariables(metadata?.lookupView.fetchxml ?? "" + customFilter ?? "");
+    const templateVar = getHandlebarsVariables((metadata?.lookupView.fetchxml ?? "") + (customFilter ?? ""));
     if (templateVar.length) {
       templateVar.forEach((v) => {
         Xrm.Page.data.entity.attributes.get(v)?.addOnChange(invalidateFetchDataFn);


### PR DESCRIPTION
### Previous Behavior
- filtering not refreshed when dependent fields change due to incorrect input fetch template

### New Behavior
- fixed extracting dynamic variables

### Related Issue(s)
- fixed #134 
