### PR TITLE
fixed dynamic lookup variables

### DIFF
--- a/LookdownComponent/Lookdown/ControlManifest.Input.xml
+++ b/LookdownComponent/Lookdown/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="Lookdown" version="1.3.0" display-name-key="Lookdown v1.3.0" description-key="Display a lookup control as a dropdown" control-type="virtual" >
+  <control namespace="DCEPCF" constructor="Lookdown" version="1.3.1" display-name-key="Lookdown v1.3.1" description-key="Display a lookup control as a dropdown" control-type="virtual" >
     <external-service-usage enabled="false">
       <!--UNCOMMENT TO ADD EXTERNAL DOMAINS
       <domain></domain>

--- a/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
@@ -19,6 +19,7 @@ import { useEntityOptions, useLanguagePack, useMetadata } from "../services/Data
 import { getClassicDropdownOptions } from "../services/DropdownHelper";
 import { getCustomFilterString, getHandlebarsVariables } from "../services/TemplateService";
 import { EntityOption, LookdownControlProps, OpenRecordMode } from "../types/typings";
+import { useAttributeOnChange } from "../hooks/useAttributeOnChange";
 
 const DEFAULT_BORDER_STYLES: IStyle = {
   borderColor: "#666",
@@ -111,6 +112,8 @@ export default function LookdownControlClassic({
     showIcon,
     iconSize
   );
+
+  useAttributeOnChange(metadata, customFilter);
 
   const isError = isErrorLanguagePack || isErrorMetadata || isErrorEntityOptions;
 
@@ -272,19 +275,6 @@ export default function LookdownControlClassic({
       },
     ],
   };
-
-  const invalidateFetchDataFn = useCallback((context) => {
-    queryClient.invalidateQueries({ queryKey: ["entityRecords"] });
-  }, []);
-
-  useEffect(() => {
-    const templateVar = getHandlebarsVariables((metadata?.lookupView.fetchxml ?? "") + (customFilter ?? ""));
-    if (templateVar.length) {
-      templateVar.forEach((v) => {
-        Xrm.Page.data.entity.attributes.get(v)?.addOnChange(invalidateFetchDataFn);
-      });
-    }
-  }, [metadata?.lookupView.fetchxml, customFilter]);
 
   return (
     <Stack horizontal styles={{ root: { width: "100%" } }}>

--- a/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlNewLook.tsx
@@ -23,6 +23,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useEntityOptions, useLanguagePack, useMetadata } from "../services/DataverseService";
 import { getCustomFilterString, getHandlebarsVariables } from "../services/TemplateService";
 import { EntityOption, LookdownControlProps, OpenRecordMode } from "../types/typings";
+import { useAttributeOnChange } from "../hooks/useAttributeOnChange";
 
 const useStyle = makeStyles({
   root: {
@@ -101,6 +102,8 @@ export default function LookdownControlNewLook({
     iconSize
   );
 
+  useAttributeOnChange(metadata, customFilter);
+
   const isError = isErrorLanguagePack || isErrorMetadata || isErrorEntityOptions;
 
   useEffect(() => {
@@ -117,27 +120,6 @@ export default function LookdownControlNewLook({
     setSelectedValues([]);
     setSelectedDisplayText(selectedText ?? "");
   }, [selectedId, selectedText, entityOptions]);
-
-  const invalidateFetchDataFn = useCallback((context) => {
-    queryClient.invalidateQueries({ queryKey: ["entityRecords"] });
-  }, []);
-
-  useEffect(() => {
-    const templateVar = getHandlebarsVariables((metadata?.lookupView.fetchxml ?? "") + (customFilter ?? ""));
-    if (templateVar.length) {
-      templateVar.forEach((v) => {
-        Xrm.Page.data.entity.attributes.get(v)?.addOnChange(invalidateFetchDataFn);
-      });
-    }
-
-    // TODO: not sure why this is not working
-    // return () => {
-    //   console.log("cleanup");
-    //   templateVar.forEach((v) => {
-    //     Xrm.Page.data.entity.attributes.get(v)?.removeOnChange(invalidateFetchDataFn);
-    //   });
-    // };
-  }, [metadata?.lookupView.fetchxml, customFilter]);
 
   const getSelectedOptionDisplay = () => {
     const selectedOption = entityOptions?.find((item) => item.id === selectedValues.at(0) ?? "");

--- a/LookdownComponent/Lookdown/hooks/useAttributeOnChange.ts
+++ b/LookdownComponent/Lookdown/hooks/useAttributeOnChange.ts
@@ -1,0 +1,28 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect } from "react";
+import { getHandlebarsVariables } from "../services/TemplateService";
+import { IMetadata } from "../types/metadata";
+
+export function useAttributeOnChange(metadata: IMetadata | undefined, customFilter?: string | null) {
+  const queryClient = useQueryClient();
+  const invalidateFetchDataFn = useCallback((context) => {
+    queryClient.invalidateQueries({ queryKey: ["entityRecords"] });
+  }, []);
+
+  useEffect(() => {
+    const templateVar = getHandlebarsVariables((metadata?.lookupView.fetchxml ?? "") + (customFilter ?? ""));
+    if (templateVar.length) {
+      templateVar.forEach((v) => {
+        Xrm.Page.data.entity.attributes.get(v)?.addOnChange(invalidateFetchDataFn);
+      });
+    }
+
+    // TODO: not sure why this is not working
+    // return () => {
+    //   console.log("cleanup");
+    //   templateVar.forEach((v) => {
+    //     Xrm.Page.data.entity.attributes.get(v)?.removeOnChange(invalidateFetchDataFn);
+    //   });
+    // };
+  }, [metadata?.lookupView.fetchxml, customFilter]);
+}

--- a/LookdownComponent/Lookdown/services/TemplateService.ts
+++ b/LookdownComponent/Lookdown/services/TemplateService.ts
@@ -62,13 +62,15 @@ export function getCustomFilterString(customFilter: string) {
 export function getHandlebarsVariables(input: string): string[] {
   const ast = Handlebars.parseWithoutProcessing(input);
 
-  return ast.body
+  const hbVars = ast.body
     .filter(({ type }: hbs.AST.Statement) => type === "MustacheStatement")
     .map((statement: hbs.AST.Statement) => {
       const moustacheStatement: hbs.AST.MustacheStatement = statement as hbs.AST.MustacheStatement;
       const paramsExpressionList = moustacheStatement.params as hbs.AST.PathExpression[];
       const pathExpression = moustacheStatement.path as hbs.AST.PathExpression;
-
-      return paramsExpressionList[0]?.original || pathExpression.original;
+      const original = paramsExpressionList[0]?.original || pathExpression.original;
+      return original.split(".")[0];
     });
+
+  return Array.from(new Set(hbVars));
 }

--- a/solution/src/Other/Solution.xml
+++ b/solution/src/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="DCE PCF Components" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.1.0.0</Version>
+    <Version>1.1.0.1</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>
@@ -20,7 +20,7 @@
       </LocalizedNames>
       <Descriptions>
         <!-- Description of Cds Publisher in language code -->
-        <Description description="DynamicsCrmExp PCF Components Library.&#xA;- PolyLookup v1.6.0&#xA;- Lookdown v1.3.0&#xA;- TimePicker v1.0.1&#xA;&#xA;For documentation and configuration, please visit: https://github.com/khoait/DCE.PCF/wiki&#xA;&#xA;For feedback and report issues, please visit: https://github.com/khoait/DCE.PCF/issues" languagecode="1033" />
+        <Description description="DynamicsCrmExp PCF Components Library.&#xA;- PolyLookup v1.6.1&#xA;- Lookdown v1.3.1&#xA;- TimePicker v1.0.1&#xA;&#xA;For documentation and configuration, please visit: https://github.com/khoait/DCE.PCF/wiki&#xA;&#xA;For feedback and report issues, please visit: https://github.com/khoait/DCE.PCF/issues" languagecode="1033" />
       </Descriptions>
       <EMailAddress xsi:nil="true"></EMailAddress>
       <SupportingWebsiteUrl xsi:nil="true">https://github.com/khoait/DCE.PCF/issues</SupportingWebsiteUrl>


### PR DESCRIPTION
### Previous Behavior
- can't extract attribute name from complex variable such as lookup in custom filter

### New Behavior
- extract attribute name by spliting by `.`

### Related Issue(s)
- fixed #161 
