### PR TITLE
output selectedOptionText

### DIFF
--- a/PolyLookupComponent/PolyLookup/components/PolyLookupControlClassic.tsx
+++ b/PolyLookupComponent/PolyLookup/components/PolyLookupControlClassic.tsx
@@ -132,7 +132,7 @@ export default function PolyLookupControlClassic({
       selectedItems?.map((i) => {
         return {
           id: i.associatedId,
-          name: i.associatedName,
+          name: i.selectedOptionText,
           etn: metadata?.associatedEntity.LogicalName ?? "",
         } as EntityReference;
       })

--- a/PolyLookupComponent/PolyLookup/components/PolyLookupControlNewLook.tsx
+++ b/PolyLookupComponent/PolyLookup/components/PolyLookupControlNewLook.tsx
@@ -179,7 +179,7 @@ export default function PolyLookupControlNewLook({
       selectedOptions?.map((i) => {
         return {
           id: i.associatedId,
-          name: i.associatedName,
+          name: i.selectedOptionText,
           etn: metadata?.associatedEntity.LogicalName ?? "",
         } as EntityReference;
       })


### PR DESCRIPTION
### Previous Behavior
- primary name was used in outputs

### New Behavior
- selected item text is used instead

### Related Issue(s)
- completed #209 
