### PR TITLE
load selected item separately

### DIFF
--- a/LookdownComponent/Lookdown/ControlManifest.Input.xml
+++ b/LookdownComponent/Lookdown/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="Lookdown" version="1.3.3" display-name-key="Lookdown v1.3.3" description-key="Display a lookup control as a dropdown" control-type="virtual" >
+  <control namespace="DCEPCF" constructor="Lookdown" version="1.3.4" display-name-key="Lookdown v1.3.4" description-key="Display a lookup control as a dropdown" control-type="virtual" >
     <external-service-usage enabled="false">
       <!--UNCOMMENT TO ADD EXTERNAL DOMAINS
       <domain></domain>

--- a/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
+++ b/LookdownComponent/Lookdown/components/LookdownControlClassic.tsx
@@ -22,6 +22,7 @@ import { useAttributeOnChange } from "../hooks/useAttributeOnChange";
 import { useEntityOptions } from "../hooks/queries/useEntityOptions";
 import { useLanguagePack } from "../hooks/queries/useLanguagePack";
 import { useMetadata } from "../hooks/queries/useMetadata";
+import { useSelectedItem } from "../hooks/queries/useSelectedItem";
 
 const DEFAULT_BORDER_STYLES: IStyle = {
   borderColor: "#666",
@@ -105,19 +106,26 @@ export default function LookdownControlClassic({
 
   const { data: metadata, isError: isErrorMetadata } = useMetadata(lookupEntity ?? "", lookupViewId ?? "");
 
+  const { data: selectedOption, isError: isErrorSelectedOption } = useSelectedItem(
+    metadata,
+    selectedId,
+    selectedItemTemplate,
+    showIcon,
+    iconSize
+  );
+
   const { data: entityOptions, isError: isErrorEntityOptions } = useEntityOptions(
     metadata,
     customFilter,
     groupBy,
     optionTemplate,
-    selectedItemTemplate,
     showIcon,
     iconSize
   );
 
   useAttributeOnChange(metadata, customFilter);
 
-  const isError = isErrorLanguagePack || isErrorMetadata || isErrorEntityOptions;
+  const isError = isErrorLanguagePack || isErrorMetadata || isErrorSelectedOption || isErrorEntityOptions;
 
   const onRenderOption = (
     option?: IDropdownOption<EntityOption>,
@@ -171,7 +179,7 @@ export default function LookdownControlClassic({
             height={option.data.iconSize}
           ></Image>
         ) : null}
-        <Label styles={selectionOptionLabelStyles}>{option.data?.selectedOptionText}</Label>
+        <Label styles={selectionOptionLabelStyles}>{option.data?.optionText}</Label>
       </Stack>
     );
   };
@@ -292,7 +300,7 @@ export default function LookdownControlClassic({
         <Dropdown
           selectedKey={isError ? null : selectedId ?? null}
           placeholder={isError ? languagePack.LoadDataErrorMessage : "---"}
-          options={getClassicDropdownOptions(entityOptions ?? [], groupBy ?? null, languagePack)}
+          options={getClassicDropdownOptions(entityOptions ?? [], selectedOption, groupBy ?? null, languagePack)}
           disabled={isError ? true : disabled}
           onChange={(event, option) => {
             if (!onChange) return;

--- a/LookdownComponent/Lookdown/hooks/queries/useEntityOptions.ts
+++ b/LookdownComponent/Lookdown/hooks/queries/useEntityOptions.ts
@@ -9,7 +9,6 @@ export function useEntityOptions(
   customFilter?: string | null,
   groupBy?: string | null,
   optionTemplate?: string | null,
-  selectedItemTemplate?: string | null,
   iconOptions?: ShowIconOptions,
   iconSize?: IconSizes
 ) {
@@ -32,34 +31,21 @@ export function useEntityOptions(
   }
 
   return useQuery({
-    queryKey: [
-      "entityRecords",
-      entitySetName,
-      lookupViewFetchXml,
-      customFilter,
-      groupBy,
-      optionTemplate,
-      selectedItemTemplate,
-    ],
-    queryFn: () => {
-      const templateColumns: string[] = [];
-      if (optionTemplate || selectedItemTemplate) {
-        templateColumns.push(...getHandlebarsVariables(optionTemplate ?? "" + " " + selectedItemTemplate ?? ""));
-      }
-      const populatedFetchXml = getFetchTemplateString(lookupViewFetchXml ?? "", customFilter, templateColumns);
-      return getEntityRecords(
+    queryKey: ["entityRecords", entitySetName, lookupViewFetchXml, customFilter, groupBy, optionTemplate],
+    queryFn: () =>
+      getEntityRecords(
         entitySetName,
         metadata?.lookupEntity.PrimaryIdAttribute ?? "",
         metadata?.lookupEntity.PrimaryNameAttribute ?? "",
-        populatedFetchXml,
+        lookupViewFetchXml,
+        customFilter,
         groupBy,
         optionTemplate,
-        selectedItemTemplate,
         iconOptions,
         iconTemplate,
         iconSize
-      );
-    },
+      ),
+
     enabled: !!entitySetName && !!lookupViewFetchXml,
   });
 }

--- a/LookdownComponent/Lookdown/hooks/queries/useSelectedItem.ts
+++ b/LookdownComponent/Lookdown/hooks/queries/useSelectedItem.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { IconSizes, ShowIconOptions } from "../../types/typings";
+import { getHandlebarsVariables } from "../../services/TemplateService";
+import { useMetadata } from "./useMetadata";
+import { IMetadata } from "../../types/metadata";
+import { getSelectedEntityOption } from "../../services/DataverseService";
+
+export function getSelectedItemQueryOptions(
+  entitySetName: string,
+  selectedId: string | null | undefined,
+  primaryIdAttribute: string,
+  primaryNameAttribute: string,
+  selectedItemTemplate?: string | null,
+  iconOptions?: ShowIconOptions,
+  iconTemplate?: string,
+  iconSize?: IconSizes
+) {
+  return {
+    queryKey: ["selectedItem", selectedId, selectedItemTemplate],
+    queryFn: () =>
+      getSelectedEntityOption(
+        entitySetName,
+        selectedId,
+        primaryIdAttribute,
+        primaryNameAttribute,
+        selectedItemTemplate,
+        iconOptions,
+        iconTemplate,
+        iconSize
+      ),
+    enabled: !!entitySetName,
+    staleTime: 5000,
+  };
+}
+
+export function useSelectedItem(
+  metadata: IMetadata | undefined,
+  selectedId: string | null | undefined,
+  selectedItemTemplate?: string | null,
+  iconOptions?: ShowIconOptions,
+  iconSize?: IconSizes
+) {
+  const entitySetName = metadata?.lookupEntity.EntitySetName ?? "";
+  const entityIcon =
+    metadata?.lookupEntity.IconVectorName ??
+    (iconSize === IconSizes.Large
+      ? metadata?.lookupEntity.IconMediumName ?? metadata?.lookupEntity.IconSmallName
+      : metadata?.lookupEntity.IconSmallName);
+
+  const recordImageUrlTemplate = metadata?.lookupEntity.RecordImageUrlTemplate;
+
+  let iconTemplate = "";
+  if (iconOptions === ShowIconOptions.RecordImage) {
+    iconTemplate = recordImageUrlTemplate ?? "";
+  } else if (iconOptions === ShowIconOptions.EntityIcon) {
+    iconTemplate = entityIcon ?? "";
+  }
+
+  return useQuery(
+    getSelectedItemQueryOptions(
+      entitySetName,
+      selectedId,
+      metadata?.lookupEntity.PrimaryIdAttribute ?? "",
+      metadata?.lookupEntity.PrimaryNameAttribute ?? "",
+      selectedItemTemplate,
+      iconOptions,
+      iconTemplate,
+      iconSize
+    )
+  );
+}

--- a/LookdownComponent/Lookdown/services/DropdownHelper.ts
+++ b/LookdownComponent/Lookdown/services/DropdownHelper.ts
@@ -4,6 +4,7 @@ import { EntityOption } from "../types/typings";
 
 export function getClassicDropdownOptions(
   entityOptions: EntityOption[],
+  selectedOption: EntityOption | null | undefined,
   groupBy: string | null,
   languagePack: LanguagePack
 ) {
@@ -49,6 +50,15 @@ export function getClassicDropdownOptions(
       key: "no-records",
       text: languagePack?.EmptyListMessage ?? "",
       disabled: true,
+    });
+  }
+
+  if (selectedOption && !options.some((o) => o.key === selectedOption.id)) {
+    options.push({
+      key: selectedOption.id,
+      text: selectedOption.optionText,
+      data: selectedOption,
+      hidden: true,
     });
   }
 

--- a/LookdownComponent/Lookdown/types/typings.ts
+++ b/LookdownComponent/Lookdown/types/typings.ts
@@ -42,7 +42,6 @@ export interface EntityOption {
   id: string;
   primaryName: string;
   optionText: string;
-  selectedOptionText: string;
   iconSrc?: string;
   iconSize?: number;
   group?: string;


### PR DESCRIPTION
### Previous Behavior
- selected item was filtered from available options. if the selected option was not in the list (when it is deactivated, or lookup view changed), the selected item couldn't be displayed

### New Behavior
- use a separate hook to load selected item

### Related Issue(s)
- fixed #219 
