### PR TITLE
fixed timepicker classic dropdown options and refresh output on dateAnchor change

### DIFF
--- a/TimePickerComponent/TimePicker/ControlManifest.Input.xml
+++ b/TimePickerComponent/TimePicker/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="TimePicker" version="1.0.3" display-name-key="TimePicker v1.0.3" description-key="TimePicker displays the time part and supports quick values with a dropdown" control-type="standard" >
+  <control namespace="DCEPCF" constructor="TimePicker" version="1.0.4" display-name-key="TimePicker v1.0.4" description-key="TimePicker displays the time part and supports quick values with a dropdown" control-type="standard" >
     <external-service-usage enabled="false">   
     </external-service-usage>    
     <property name="boundField" display-name-key="Bound Field" description-key="The field that the component is bound to" of-type="DateAndTime.DateAndTime" usage="bound" required="true" />   

--- a/TimePickerComponent/TimePicker/ControlManifest.Input.xml
+++ b/TimePickerComponent/TimePicker/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="TimePicker" version="1.0.1" display-name-key="TimePicker v1.0.1" description-key="TimePicker displays the time part and supports quick values with a dropdown" control-type="standard" >
+  <control namespace="DCEPCF" constructor="TimePicker" version="1.0.2" display-name-key="TimePicker v1.0.2" description-key="TimePicker displays the time part and supports quick values with a dropdown" control-type="standard" >
     <external-service-usage enabled="false">   
     </external-service-usage>    
     <property name="boundField" display-name-key="Bound Field" description-key="The field that the component is bound to" of-type="DateAndTime.DateAndTime" usage="bound" required="true" />   

--- a/TimePickerComponent/TimePicker/ControlManifest.Input.xml
+++ b/TimePickerComponent/TimePicker/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DCEPCF" constructor="TimePicker" version="1.0.2" display-name-key="TimePicker v1.0.2" description-key="TimePicker displays the time part and supports quick values with a dropdown" control-type="standard" >
+  <control namespace="DCEPCF" constructor="TimePicker" version="1.0.3" display-name-key="TimePicker v1.0.3" description-key="TimePicker displays the time part and supports quick values with a dropdown" control-type="standard" >
     <external-service-usage enabled="false">   
     </external-service-usage>    
     <property name="boundField" display-name-key="Bound Field" description-key="The field that the component is bound to" of-type="DateAndTime.DateAndTime" usage="bound" required="true" />   

--- a/TimePickerComponent/TimePicker/components/TimePickerControlClassic.tsx
+++ b/TimePickerComponent/TimePicker/components/TimePickerControlClassic.tsx
@@ -154,16 +154,16 @@ export default function TimePickerControlClassic({
 
   // trigger onChange when dateAnchor changes
   useEffect(() => {
-    if (selectedTime && dateAnchor) {
+    if (selectedTime && dateAnchorValue) {
       const newSelectedTime = new Date(selectedTime);
-      newSelectedTime.setFullYear(dateAnchor.getFullYear(), dateAnchor.getMonth(), dateAnchor.getDate());
+      newSelectedTime.setFullYear(dateAnchorValue.getFullYear(), dateAnchorValue.getMonth(), dateAnchorValue.getDate());
       setSelectedTime(newSelectedTime);
       onTimeChange?.(newSelectedTime);
-    } else if (dateAnchor === null) {
+    } else if (dateAnchorValue === null) {
       setSelectedTime(null);
       onTimeChange?.(null);
     }
-  }, [dateAnchor]);
+  }, [dateAnchorValue.getFullYear(), dateAnchorValue.getMonth(), dateAnchorValue.getDate()]);
 
   return (
     <Stack horizontal styles={{ root: { width: "100%" } }}>
@@ -183,7 +183,15 @@ export default function TimePickerControlClassic({
           styles: { root: { height: "16px", fontSize: "16px" } },
         }}
       />
-      {selectedTime ? <IconButton iconProps={{ iconName: "Cancel" }} onClick={() => onTimeChange?.(null)} /> : null}
+      {selectedTime ? (
+        <IconButton
+          iconProps={{ iconName: "Cancel" }}
+          onClick={() => {
+            setSelectedTime(null);
+            onTimeChange?.(null);
+          }}
+        />
+      ) : null}
     </Stack>
   );
 }

--- a/TimePickerComponent/TimePicker/components/TimePickerControlClassic.tsx
+++ b/TimePickerComponent/TimePicker/components/TimePickerControlClassic.tsx
@@ -1,5 +1,5 @@
 import { IComboBoxStyles, IconButton, IStyle, ITimeRange, Stack, TimePicker } from "@fluentui/react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { isValidDate } from "../services/dateService";
 import { TimePickerControlProps } from "../types/typings";
 
@@ -141,11 +141,32 @@ export default function TimePickerControlClassic({
     };
   }
 
+  // build dateAnchor from prop or selectedTime or current date at 0 hour
+  let dateAnchorValue: Date;
+  if (dateAnchor) {
+    dateAnchorValue = dateAnchor;
+  } else if (selectedTime) {
+    dateAnchorValue = new Date(selectedTime);
+  } else {
+    dateAnchorValue = new Date();
+  }
+  dateAnchorValue.setHours(0, 0, 0, 0);
+
+  // trigger onChange when dateAnchor changes
+  useEffect(() => {
+    if (selectedTime && dateAnchor) {
+      const newSelectedTime = new Date(selectedTime);
+      newSelectedTime.setFullYear(dateAnchor.getFullYear(), dateAnchor.getMonth(), dateAnchor.getDate());
+      setSelectedTime(newSelectedTime);
+      onTimeChange?.(newSelectedTime);
+    }
+  }, [dateAnchor]);
+
   return (
     <Stack horizontal styles={{ root: { width: "100%" } }}>
       <TimePicker
         value={selectedTime ?? undefined}
-        dateAnchor={dateAnchor ?? undefined}
+        dateAnchor={dateAnchorValue}
         disabled={disabled}
         placeholder={placeholder}
         increments={increment}

--- a/TimePickerComponent/TimePicker/components/TimePickerControlClassic.tsx
+++ b/TimePickerComponent/TimePicker/components/TimePickerControlClassic.tsx
@@ -159,6 +159,9 @@ export default function TimePickerControlClassic({
       newSelectedTime.setFullYear(dateAnchor.getFullYear(), dateAnchor.getMonth(), dateAnchor.getDate());
       setSelectedTime(newSelectedTime);
       onTimeChange?.(newSelectedTime);
+    } else if (dateAnchor === null) {
+      setSelectedTime(null);
+      onTimeChange?.(null);
     }
   }, [dateAnchor]);
 

--- a/TimePickerComponent/TimePicker/components/TimePickerControlNewLook.tsx
+++ b/TimePickerComponent/TimePicker/components/TimePickerControlNewLook.tsx
@@ -1,4 +1,4 @@
-import { FluentProvider, Theme, makeStyles, shorthands, tokens } from "@fluentui/react-components";
+import { FluentProvider, Input, Theme, makeStyles, shorthands, tokens } from "@fluentui/react-components";
 import { Clock16Regular } from "@fluentui/react-icons";
 import { TimePicker, TimePickerProps, formatDateToTimeString } from "@fluentui/react-timepicker-compat";
 import React, { useEffect, useState } from "react";
@@ -72,29 +72,46 @@ export default function TimePickerControlNewLook({
       newSelectedTime.setFullYear(dateAnchor.getFullYear(), dateAnchor.getMonth(), dateAnchor.getDate());
       setSelectedTime(newSelectedTime);
       onTimeChange?.(newSelectedTime);
+    } else if (dateAnchor === null) {
+      setSelectedTime(null);
+      onTimeChange?.(null);
     }
   }, [dateAnchor]);
 
+  const theme = fluentDesign?.tokenTheme;
+  const currentTheme = disabled
+    ? {
+        ...theme,
+        colorCompoundBrandStroke: theme?.colorNeutralStroke1,
+        colorCompoundBrandStrokeHover: theme?.colorNeutralStroke1Hover,
+        colorCompoundBrandStrokePressed: theme?.colorNeutralStroke1Pressed,
+        colorCompoundBrandStrokeSelected: theme?.colorNeutralStroke1Selected,
+      }
+    : theme;
+
   return (
-    <FluentProvider theme={fluentDesign?.tokenTheme}>
-      <TimePicker
-        className={styles.root}
-        appearance="filled-darker"
-        clearable
-        selectedTime={selectedTime}
-        value={value}
-        dateAnchor={dateAnchor ?? undefined}
-        disabled={disabled}
-        placeholder={placeholder}
-        increment={increment}
-        freeform={freeform ?? false}
-        hourCycle={hourCycle12 ? "h12" : "h23"}
-        startHour={start as any}
-        endHour={end as any}
-        onTimeChange={handleTimeChange}
-        onInput={freeform ? handleOnInput : undefined}
-        expandIcon={<Clock16Regular />}
-      />
+    <FluentProvider theme={currentTheme}>
+      {disabled ? (
+        <Input className={styles.root} appearance="filled-darker" readOnly value={value} />
+      ) : (
+        <TimePicker
+          className={styles.root}
+          appearance="filled-darker"
+          clearable
+          selectedTime={selectedTime}
+          value={value}
+          dateAnchor={dateAnchor ?? undefined}
+          placeholder={placeholder}
+          increment={increment}
+          freeform={freeform ?? false}
+          hourCycle={hourCycle12 ? "h12" : "h23"}
+          startHour={start as any}
+          endHour={end as any}
+          onTimeChange={handleTimeChange}
+          onInput={freeform ? handleOnInput : undefined}
+          expandIcon={<Clock16Regular />}
+        />
+      )}
     </FluentProvider>
   );
 }

--- a/TimePickerComponent/TimePicker/components/TimePickerControlNewLook.tsx
+++ b/TimePickerComponent/TimePicker/components/TimePickerControlNewLook.tsx
@@ -1,7 +1,7 @@
 import { FluentProvider, Theme, makeStyles, shorthands, tokens } from "@fluentui/react-components";
 import { Clock16Regular } from "@fluentui/react-icons";
 import { TimePicker, TimePickerProps, formatDateToTimeString } from "@fluentui/react-timepicker-compat";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { TimePickerControlProps } from "../types/typings";
 
 const useStyles = makeStyles({
@@ -35,18 +35,6 @@ export default function TimePickerControlNewLook({
       : ""
   );
 
-  const handleTimeChange: TimePickerProps["onTimeChange"] = (_ev, data) => {
-    setSelectedTime(data.selectedTime);
-    setValue(data.selectedTime && data.selectedTimeText ? data.selectedTimeText : "");
-    if (onTimeChange) {
-      onTimeChange(data.selectedTime);
-    }
-  };
-
-  const handleOnInput = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(ev.target.value);
-  };
-
   let start: number | undefined;
   let end: number | undefined;
   if (startHour !== undefined) {
@@ -66,6 +54,26 @@ export default function TimePickerControlNewLook({
       end = 1;
     }
   }
+
+  const handleTimeChange: TimePickerProps["onTimeChange"] = (_ev, data) => {
+    setSelectedTime(data.selectedTime);
+    setValue(data.selectedTime && data.selectedTimeText ? data.selectedTimeText : "");
+    onTimeChange?.(data.selectedTime);
+  };
+
+  const handleOnInput = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(ev.target.value);
+  };
+
+  // trigger onChange when dateAnchor changes
+  useEffect(() => {
+    if (selectedTime && dateAnchor) {
+      const newSelectedTime = new Date(selectedTime);
+      newSelectedTime.setFullYear(dateAnchor.getFullYear(), dateAnchor.getMonth(), dateAnchor.getDate());
+      setSelectedTime(newSelectedTime);
+      onTimeChange?.(newSelectedTime);
+    }
+  }, [dateAnchor]);
 
   return (
     <FluentProvider theme={fluentDesign?.tokenTheme}>

--- a/TimePickerComponent/TimePicker/components/TimePickerControlNewLook.tsx
+++ b/TimePickerComponent/TimePicker/components/TimePickerControlNewLook.tsx
@@ -76,7 +76,7 @@ export default function TimePickerControlNewLook({
       setSelectedTime(null);
       onTimeChange?.(null);
     }
-  }, [dateAnchor]);
+  }, [dateAnchor?.getFullYear(), dateAnchor?.getMonth(), dateAnchor?.getDate()]);
 
   const theme = fluentDesign?.tokenTheme;
   const currentTheme = disabled

--- a/TimePickerComponent/TimePicker/index.ts
+++ b/TimePickerComponent/TimePicker/index.ts
@@ -68,18 +68,20 @@ export class TimePicker implements ComponentFramework.StandardControl<IInputs, I
 
   public render(): void {
     const boundValue = this.convertToLocalDate(this.context.parameters.boundField);
-    const dateAnchor = this.convertToLocalDate(this.context.parameters.dateAnchor);
+    const dateAnchor = this.context.parameters.dateAnchor?.type
+      ? this.convertToLocalDate(this.context.parameters.dateAnchor)
+      : undefined;
 
     const props: TimePickerControlProps = {
       inputValue: boundValue,
-      dateAnchor: dateAnchor,
+      dateAnchor,
       disabled: this.context.mode.isControlDisabled,
-      placeholder: this.context.parameters.placeholder.raw ?? undefined,
-      increment: this.context.parameters.increment.raw ?? undefined,
-      hourCycle12: this.context.parameters.hourCycle12.raw === "1",
-      freeform: this.context.parameters.freeform.raw === "1",
-      startHour: this.context.parameters.startHour.raw ?? undefined,
-      endHour: this.context.parameters.endHour.raw ?? undefined,
+      placeholder: this.context.mode.isAuthoringMode ? "---" : (this.context.parameters.placeholder?.raw ?? undefined),
+      increment: this.context.parameters.increment?.raw ?? undefined,
+      hourCycle12: this.context.parameters.hourCycle12?.raw === "1",
+      freeform: this.context.parameters.freeform?.raw === "1",
+      startHour: this.context.parameters.startHour?.raw ?? undefined,
+      endHour: this.context.parameters.endHour?.raw ?? undefined,
       fluentDesign: this.context.fluentDesignLanguage,
       onTimeChange: (time) => {
         this.outputValue = time;
@@ -93,10 +95,10 @@ export class TimePicker implements ComponentFramework.StandardControl<IInputs, I
   }
 
   public convertToLocalDate(dateProperty: ComponentFramework.PropertyTypes.DateTimeProperty) {
+    if (!dateProperty?.raw) return null;
+
     if (dateProperty.attributes?.Behavior === 1) {
       // user local
-      if (!dateProperty.raw) return null;
-
       return convertDate(dateProperty.raw, this.context.userSettings.getTimeZoneOffsetMinutes(dateProperty.raw));
     } else {
       return getUtcDate(dateProperty.raw);

--- a/TimePickerComponent/TimePicker/types/extendedContext.ts
+++ b/TimePickerComponent/TimePicker/types/extendedContext.ts
@@ -6,4 +6,7 @@ interface IExtendedUserSettings extends ComponentFramework.UserSettings {
 
 export interface IExtendedContext extends ComponentFramework.Context<IInputs> {
   userSettings: IExtendedUserSettings;
+  mode: ComponentFramework.Mode & {
+    isAuthoringMode: boolean;
+  };
 }

--- a/TimePickerComponent/package-lock.json
+++ b/TimePickerComponent/package-lock.json
@@ -7478,9 +7478,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9733,10 +9733,11 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
-      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
-      "dev": true
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.3.0",

--- a/TimePickerComponent/package-lock.json
+++ b/TimePickerComponent/package-lock.json
@@ -9219,16 +9219,6 @@
         }
       ]
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9922,16 +9912,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -10613,16 +10593,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {

--- a/TimePickerComponent/package-lock.json
+++ b/TimePickerComponent/package-lock.json
@@ -5951,9 +5951,9 @@
       }
     },
     "node_modules/eazy-logger": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
-      "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.1.0.tgz",
+      "integrity": "sha512-+mn7lRm+Zf1UT/YaH8WXtpU6PIV2iOjzP6jgKoiaq/VNrjYKp+OHZGe2znaLgDeFkw8cL9ffuaUm+nNnzcYyGw==",
       "dev": true,
       "dependencies": {
         "chalk": "4.1.2"

--- a/TimePickerComponent/package-lock.json
+++ b/TimePickerComponent/package-lock.json
@@ -61,6 +61,7 @@
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
       "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -73,6 +74,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
       "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
@@ -83,36 +85,23 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
-      "integrity": "sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha512-VxLk4AHLyqcHsfKe4MZ6IQ+D+ShuByy+RfStKfSjxJoL3WBWq17VNmrz8aT8etKzqc2nAeIyLxScjpzsS4fz8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.9.0",
         "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
@@ -128,28 +117,18 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
-      "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -4001,15 +3980,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -4307,6 +4277,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.3.tgz",
+      "integrity": "sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -4547,15 +4532,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -4651,14 +4634,14 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.9.5.tgz",
-      "integrity": "sha512-APQ8IWyYDHFvKbitFKpsmZXxkzQh0yYTFacQqoVW7HwlPo3eeLprwnq5RFNmmG6iqLmvQ+xRJSDLEQCgqPh+bw==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.9.8.tgz",
+      "integrity": "sha512-eB/EtAXJ6mDLLvHrtZj/7h31qUfnC2Npr2pHGqds5+1OP7BFLsn5us+HCkwTj7Q+1sHXujLphE5Cyvq5grtV6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-rest-pipeline": "1.10.1",
-        "@azure/core-util": "1.2.0",
+        "@azure/core-auth": "1.7.2",
+        "@azure/core-rest-pipeline": "1.16.3",
         "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-web-snippet": "1.0.1",
         "@opentelemetry/api": "^1.7.0",
@@ -4915,12 +4898,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -5512,18 +5489,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -5819,15 +5784,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -7041,23 +6997,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -7451,30 +7390,31 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/TimePickerComponent/package-lock.json
+++ b/TimePickerComponent/package-lock.json
@@ -2103,12 +2103,10 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -9433,11 +9431,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/TimePickerComponent/package-lock.json
+++ b/TimePickerComponent/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@microsoft/eslint-plugin-power-apps": "^0.2.6",
         "@types/node": "^18.8.2",
-        "@types/powerapps-component-framework": "^1.3.4",
+        "@types/powerapps-component-framework": "^1.3.18",
         "@types/react": "^18.2.77",
         "@types/react-dom": "^18.2.25",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
@@ -4078,10 +4078,11 @@
       }
     },
     "node_modules/@types/powerapps-component-framework": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/@types/powerapps-component-framework/-/powerapps-component-framework-1.3.11.tgz",
-      "integrity": "sha512-UiRKiGhGaDNrKJXGKUzhfKo6YI9t3ay0w/+yFGS8q8glweRMSQSNd/WVJI2ip8vbWoBkZ2KORaKShWCP089vpw==",
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/@types/powerapps-component-framework/-/powerapps-component-framework-1.3.18.tgz",
+      "integrity": "sha512-g5JNTwjg/IIdHOuylNAHZh7FrJzeBPCenFVEihf9tB5t0SlP82YBa0InXRa6brFpVy06RFH217sDGYixJqy2IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }

--- a/TimePickerComponent/package.json
+++ b/TimePickerComponent/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@microsoft/eslint-plugin-power-apps": "^0.2.6",
     "@types/node": "^18.8.2",
-    "@types/powerapps-component-framework": "^1.3.4",
+    "@types/powerapps-component-framework": "^1.3.18",
     "@types/react": "^18.2.77",
     "@types/react-dom": "^18.2.25",
     "@typescript-eslint/eslint-plugin": "^5.39.0",


### PR DESCRIPTION
### Previous Behavior
- options dropdown showed earlier hours at the bottom of the list.
- output wasn't updated when dateAnchor changed.

### New Behavior
- earlier hour options should display correctly.
- output is updated when dateAnchor is changed.
- updated readonly style in modern look.

### Related Issue(s)
- fixed #251 
